### PR TITLE
Various fixes to get the tools to work in my development environment

### DIFF
--- a/ClangPowerTools/ClangPowerTools/clang-build.ps1
+++ b/ClangPowerTools/ClangPowerTools/clang-build.ps1
@@ -271,8 +271,10 @@ Function Canonize-Path( [Parameter(Mandatory=$true)][string] $base
                       , [switch] $ignoreErrors)
 {
   [string] $errorAction = If ($ignoreErrors) {"SilentlyContinue"} Else {"Stop"}
-  [string] $path = Join-Path -Path "$base" -ChildPath "$child" -Resolve -ErrorAction $errorAction
-
+  [string] $path = $child
+  if (![System.IO.Path]::IsPathRooted($path)) {
+    [string] $path = Join-Path -Path "$base" -ChildPath "$child" -Resolve -ErrorAction $errorAction
+  } 
   return $path
 }
 


### PR DESCRIPTION
Fixes #2 by using `[System.IO.Path]::IsPathRooted` to determine if the 'child' path is actually an absolute path.

Fixes #4 by using a string array of valid path strings.  I'd _rather_ do this using pure regex, but that's problematic since the amount of escaping I have to do is somewhat annoying, and since the xpath version supported by powershell doesn't do xpath 2.0 (and thus regular expressions) there has to be a list of valid platform/configs anyway.  

Fixes #5 by reformatting the output from the clang-tidy process to conform to the way VS expects to see files and line numbers.  

Fixes #6 by adding the `.exe` extension to the files being searched for

Fixes #7 by adding the `-quiet` command line option to the clang-tidy call.