### PR TITLE
Clarified requirement for PowerShell 3.0

### DIFF
--- a/ClangPowerTools/ClangPowerTools/clang-build.ps1
+++ b/ClangPowerTools/ClangPowerTools/clang-build.ps1
@@ -1,4 +1,5 @@
-﻿<#
+﻿#Requires -Version 3
+<#
 .SYNOPSIS
     Compiles or tidies up code from Visual Studio .vcxproj project files.
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ http://releases.llvm.org/download.html
 
 We will automatically load clang from the default installation path *C:\Program Files\LLVM*. If you prefer to use a different location you must manually add the **bin** folder to **PATH**.  
 
+Download and install at least **PowerShell 3.0** (2.0 shipped with Windows 7 works not)
+https://www.microsoft.com/en-us/download/details.aspx?id=34595
+
 ### Download 
 
 The latest version of this extension is available at [Visual Studio Gallery](https://marketplace.visualstudio.com/items?itemName=vs-publisher-690586.ClangPowerTools).


### PR DESCRIPTION
Fixed issue #12:
* document requirement for PowerShell 3.0
* check, if script runs at least on PowerShell 3.0