### PR TITLE
Switched (internally) to -fix-errors when calling clang-tidy

### DIFF
--- a/ClangPowerTools/ClangPowerTools/clang-build.ps1
+++ b/ClangPowerTools/ClangPowerTools/clang-build.ps1
@@ -149,7 +149,8 @@ Set-Variable -name kClangDefinePrefix       -value "-D"                 -Option 
 Set-Variable -name kClangCompiler             -value "clang++"          -Option Constant
 Set-Variable -name kClangTidy                 -value "clang-tidy"       -Option Constant
 Set-Variable -name kClangTidyFlags            -value @("--")            -Option Constant
-Set-Variable -name kClangTidyFixFlags         -value @("-fix", "--")    -Option Constant
+Set-Variable -name kClangTidyFixFlags         -value @("-fix-errors"
+                                                      , "--")           -Option Constant
 Set-Variable -name kClangTidyFlagHeaderFilter -value "-header-filter="  -Option Constant
 Set-Variable -name kClangTidyFlagChecks       -value "-checks="         -Option Constant
 


### PR DESCRIPTION
 Will harmlessly ignore errors and even fix those that can be fixed.

 -fix-errors
                                 Apply suggested fixes even if compilation
                                 errors were found. If compiler errors have
                                 attached fix-its, clang-tidy will apply them as
                                 well.