### PR TITLE
silent make changes on the modified files after clang tidy

### DIFF
--- a/ClangPowerTools/ClangPowerTools/ClangPowerTools.csproj
+++ b/ClangPowerTools/ClangPowerTools/ClangPowerTools.csproj
@@ -85,6 +85,7 @@
     <Compile Include="GeneralOptions.cs">
       <SubType>Component</SubType>
     </Compile>
+    <Compile Include="SilentFileChangerEqualityComparer.cs" />
     <Compile Include="IItem.cs" />
     <Compile Include="ItemsCollector.cs" />
     <Compile Include="OutputWindowConstants.cs" />
@@ -93,6 +94,8 @@
     <Compile Include="PowerShellWrapper.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SettingsCommand.cs" />
+    <Compile Include="SilentFileChanger.cs" />
+    <Compile Include="SilentFileChangerGuard.cs" />
     <Compile Include="StringArrayConverter.cs" />
     <Compile Include="TidyCommand.cs" />
     <Compile Include="ClangPowerToolsPackage.cs" />

--- a/ClangPowerTools/ClangPowerTools/FilePathCollector.cs
+++ b/ClangPowerTools/ClangPowerTools/FilePathCollector.cs
@@ -16,6 +16,12 @@ namespace ClangPowerTools
 
     #endregion
 
+    #region Properties
+
+    public List<string> Files => mFilesPath; 
+
+    #endregion
+
     #region Public Methods
 
     //Return the common prefix of all paths stored in the mFilePath list

--- a/ClangPowerTools/ClangPowerTools/SilentFileChanger.cs
+++ b/ClangPowerTools/ClangPowerTools/SilentFileChanger.cs
@@ -1,0 +1,121 @@
+﻿using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Shell.Interop;
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using IServiceProvider = System.IServiceProvider;
+using ShellConstants = Microsoft.VisualStudio.Shell.Interop.Constants;
+
+namespace ClangPowerTools
+{
+  public class SilentFileChanger
+  {
+    #region Members
+
+    private string mDocumentFileName;
+    private bool mIsSuspending;
+    private bool mReloadDocument;
+
+    private IServiceProvider mSite;
+    private IVsPersistDocData mPersistDocData = null;
+    private IVsDocDataFileChangeControl mFileChangeControl;
+
+    private IntPtr mDocData = new IntPtr();
+
+    #endregion
+
+    #region Properties
+
+    public string DocumentFileName => mDocumentFileName;
+
+    #endregion
+
+    #region Ctor
+
+    public SilentFileChanger() { }
+
+    public SilentFileChanger(IServiceProvider aSite, string aDocument, bool aReloadDocument)
+    {
+      mSite = aSite;
+      mDocumentFileName = aDocument;
+      mReloadDocument = aReloadDocument;
+    }
+
+    #endregion
+
+    #region Public methods
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1800:DoNotCastUnnecessarily")]
+    public void Suspend()
+    {
+      if (mIsSuspending)
+        return;
+
+      mDocData = IntPtr.Zero;
+      try
+      {
+        IVsRunningDocumentTable rdt = mSite.GetService(typeof(SVsRunningDocumentTable)) as IVsRunningDocumentTable;
+        if (rdt == null)
+          return;
+
+        ErrorHandler.ThrowOnFailure(rdt.FindAndLockDocument((uint)_VSRDTFLAGS.RDT_NoLock, mDocumentFileName,
+          out IVsHierarchy hierarchy, out uint itemId, out mDocData, out uint docCookie));
+
+        if ((docCookie == (uint)ShellConstants.VSDOCCOOKIE_NIL) || mDocData == IntPtr.Zero)
+          return;
+
+        IVsFileChangeEx fileChange = mSite.GetService(typeof(SVsFileChangeEx)) as IVsFileChangeEx;
+        if (fileChange == null)
+          return;
+
+        mIsSuspending = true;
+        ErrorHandler.ThrowOnFailure(fileChange.IgnoreFile(0, mDocumentFileName, 1));
+        if (mDocData == IntPtr.Zero)
+          return;
+
+        mPersistDocData = null;
+        object unknown = Marshal.GetObjectForIUnknown(mDocData);
+        if (!(unknown is IVsPersistDocData))
+          return;
+
+        mPersistDocData = (IVsPersistDocData)unknown;
+        if (!(mPersistDocData is IVsDocDataFileChangeControl))
+          return;
+
+        mFileChangeControl = (IVsDocDataFileChangeControl)mPersistDocData;
+        if (mFileChangeControl != null)
+          ErrorHandler.ThrowOnFailure(mFileChangeControl.IgnoreFileChanges(1));
+      }
+      catch (InvalidCastException e)
+      {
+        Trace.WriteLine("Exception" + e.Message);
+      }
+      finally
+      {
+        if (mDocData != IntPtr.Zero)
+          Marshal.Release(mDocData);
+      }
+    }
+
+    public void Resume()
+    {
+      if (!mIsSuspending || mPersistDocData == null)
+        return;
+
+      if (mPersistDocData != null && mReloadDocument)
+        mPersistDocData.ReloadDocData(0);
+
+      IVsFileChangeEx fileChange = mSite.GetService(typeof(SVsFileChangeEx)) as IVsFileChangeEx;
+      if (fileChange == null)
+        return;
+
+      mIsSuspending = false;
+      ErrorHandler.ThrowOnFailure(fileChange.SyncFile(mDocumentFileName));
+      ErrorHandler.ThrowOnFailure(fileChange.IgnoreFile(0, mDocumentFileName, 0));
+      if (mFileChangeControl != null)
+        ErrorHandler.ThrowOnFailure(mFileChangeControl.IgnoreFileChanges(0));
+    }
+
+    #endregion
+  }
+}

--- a/ClangPowerTools/ClangPowerTools/SilentFileChangerEqualityComparer.cs
+++ b/ClangPowerTools/ClangPowerTools/SilentFileChangerEqualityComparer.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace ClangPowerTools
+{
+  public class SilentFileChangerEqualityComparer : IEqualityComparer<SilentFileChanger>
+  {
+    #region Public methods
+
+    public bool Equals(SilentFileChanger obj1, SilentFileChanger obj2)
+    {
+      if (obj2 == null && obj1 == null)
+        return true;
+      else if (obj1 == null | obj2 == null)
+        return false;
+      else if (obj1.DocumentFileName.ToLower() == obj2.DocumentFileName.ToLower())
+        return true;
+      else
+        return false;
+    }
+
+    public int GetHashCode(SilentFileChanger obj)
+    {
+      return obj.GetHashCode();
+    }
+
+    #endregion
+  }
+}

--- a/ClangPowerTools/ClangPowerTools/SilentFileChangerGuard.cs
+++ b/ClangPowerTools/ClangPowerTools/SilentFileChangerGuard.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace ClangPowerTools
+{
+  public class SilentFileChangerGuard : SilentFileChanger, IDisposable
+  {
+    #region Members
+
+    private HashSet<SilentFileChanger> mFileChangers = 
+      new HashSet<SilentFileChanger>(new SilentFileChangerEqualityComparer());
+
+    #endregion
+
+    #region Public methods
+
+    public SilentFileChangerGuard() { }
+
+    public SilentFileChangerGuard(IServiceProvider aSite, string aDocument, bool aReloadDocument)
+      : base(aSite, aDocument, aReloadDocument) => Suspend();
+
+    public void Add(SilentFileChanger aFileChanger)
+    {
+      aFileChanger.Suspend();
+      mFileChangers.Add(aFileChanger);
+    }
+
+    public void AddRange(IServiceProvider aServiceProvider, List<string> aFilesPath)
+    {
+      foreach (string filePath in aFilesPath)
+        this.Add(new SilentFileChanger(aServiceProvider, filePath, true));
+    }
+
+    public void Dispose()
+    {
+      foreach (SilentFileChanger file in mFileChangers)
+        file.Resume();
+      Resume();
+    }
+    #endregion
+  }
+}


### PR DESCRIPTION
Before Visual Studio prompted you to reload the files after clang tidy was executed. Now the changes are made in silence and modified files are open in editor.