### PR TITLE
Fix locating project CPP files when there is no pre-compiled header

### DIFF
--- a/ClangPowerTools/ClangPowerTools/clang-build.ps1
+++ b/ClangPowerTools/ClangPowerTools/clang-build.ps1
@@ -352,7 +352,7 @@ Function Get-ProjectCpps([Parameter(Mandatory=$true)][string] $vcxprojPath,
 
   [string[]] $cpps = $vcxproj.Project.ItemGroup.ClCompile                     | 
                      Where-Object { ($_.Include -ne $null)             -and 
-                                    ($_.Include -notmatch $pchCppName) -and 
+                                    ([string]::IsNullOrEmpty($pchCppName) -or ($_.Include -notmatch $pchCppName)) -and 
                                     ($_.Include -match $kExtensionCpp) 
                                   }                                           | 
                      ForEach-Object { Canonize-Path -base (Get-FileDirectory($vcxprojPath)) `


### PR DESCRIPTION
When working with a project with no PCH `Get-ProjectCpps` always returns null, because `$_.Include -notmatch $pchCppName` always fails.  

Fixes #24 