### PR TITLE
Select the containing project only when a command was given from tab file or toolbar

### DIFF
--- a/ClangPowerTools/ClangPowerTools/ActiveWindowProperties.cs
+++ b/ClangPowerTools/ClangPowerTools/ActiveWindowProperties.cs
@@ -15,7 +15,8 @@ namespace ClangPowerTools
       activeWindow.Activate();
 
       var projectItem = activeWindow.ProjectItem;
-      SelectContainingProject(aDte, projectItem);
+      if( null != projectItem )
+        SelectContainingProject(aDte, projectItem);
       
       return activeWindow.ProjectItem;
     }


### PR DESCRIPTION
fixed the commands execution from Solution Explorer Context Menu tab
caused by modifications for commands execution from tab file and toolbar