### PR TITLE
Evaluate msbuild conditions

### DIFF
--- a/ClangPowerTools/ClangPowerTools/clang-build.ps1
+++ b/ClangPowerTools/ClangPowerTools/clang-build.ps1
@@ -280,10 +280,10 @@ Set-Variable -name kVStudioDefaultPlatformToolset -Value "v141" -option Constant
 
 Function Exit-Script([Parameter(Mandatory=$false)][int] $code = 0)
 {
+  Write-Verbose-Array -array $global:FilesToDeleteWhenScriptQuits -name "Cleaning up PCH temporaries"
   # Clean-up
   foreach ($file in $global:FilesToDeleteWhenScriptQuits)
   {
-    Write-Verbose "Cleaning up $file"
     Remove-Item $file -ErrorAction SilentlyContinue | Out-Null
   }
 
@@ -316,11 +316,10 @@ Function Set-Var([parameter(Mandatory=$false)][string] $name,
 
 Function Clear-Vars()
 {
-  Write-Verbose "Clearing project specific variables"
+  Write-Verbose-Array -array $global:ProjectSpecificVariables -name "Deleting project specific variables"
 
   foreach ($var in $global:ProjectSpecificVariables)
   {
-    Write-Verbose "  DEL_VAR $var"
     Remove-Variable -name $var -scope Global
   }
 

--- a/ClangPowerTools/ClangPowerTools/clang-build.ps1
+++ b/ClangPowerTools/ClangPowerTools/clang-build.ps1
@@ -303,7 +303,7 @@ Function Fail-Script([parameter(Mandatory=$false)][string] $msg = "Got errors.")
 Function Set-Var([parameter(Mandatory=$false)][string] $name,
                  [parameter(Mandatory=$false)][string] $value)
 {
-  Write-Debug "SET_VARIABLE $name : $value"
+  Write-Debug "SET_VAR $name : $value"
   Set-Variable -name $name -Value $value -Scope Global
   
   $global:ProjectSpecificVariables.Add($name) | Out-Null
@@ -315,7 +315,7 @@ Function Clear-Vars()
 
   foreach ($var in $global:ProjectSpecificVariables)
   {
-    Write-Debug "  deleting $var"
+    Write-Debug "  DEL_VAR $var"
     Remove-Variable -name $var -scope Global
   }
 

--- a/ClangPowerTools/ClangPowerTools/clang-build.ps1
+++ b/ClangPowerTools/ClangPowerTools/clang-build.ps1
@@ -299,6 +299,13 @@ Function Fail-Script([parameter(Mandatory=$false)][string] $msg = "Got errors.")
   Exit-Script($kScriptFailsExitCode)
 }
 
+Function Set-Var([parameter(Mandatory=$false)][string] $name,
+                 [parameter(Mandatory=$false)][string] $value)
+{
+  Write-Debug "SET_VARIABLE $name : $value"
+  Set-Variable -name $name -Value $value -Scope Global
+}
+
 Function Write-Message([parameter(Mandatory=$true)][string] $msg
                       ,[Parameter(Mandatory=$true)][System.ConsoleColor] $color)
 {
@@ -922,8 +929,8 @@ function Get-ProjectDefaultConfigPlatformCondition()
 
   Write-Verbose "Configuration platform: $configPlatformName"
   [string[]] $configAndPlatform = $configPlatformName.Split('|')
-  Set-Variable -Name "Configuration" -Value $configAndPlatform[0] -Scope Global
-  Set-Variable -Name "Platform"      -Value $configAndPlatform[1] -Scope Global
+  Set-Var -Name "Configuration" -Value $configAndPlatform[0]
+  Set-Var -Name "Platform"      -Value $configAndPlatform[1]
 
   return "'`$(Configuration)|`$(Platform)'=='$configPlatformName'"
 }
@@ -938,8 +945,7 @@ function LoadProjectFileProperties([xml] $projectFile)
     [string] $propertyName  = $node.Name
     [string] $propertyValue = Evaluate-MSBuildExpression($node.InnerText)
 
-    Write-Verbose "PROP_SET $propertyName : $propertyValue"
-    Set-Variable -Name $propertyName -Value $propertyValue -Scope Global
+    Set-Var -Name $propertyName -Value $propertyValue
   }
 }
 
@@ -1058,6 +1064,10 @@ function LoadProject([string] $vcxprojPath)
   $global:projectFiles = @([xml] (Get-Content $vcxprojPath))
 
   $global:vcxprojPath = $vcxprojPath
+
+  $projDir = Get-FileDirectory -filePath $global:vcxprojPath
+  Set-Var -name "ProjectDir" -value $projDir
+  
   $global:xpathNS     = New-Object System.Xml.XmlNamespaceManager($global:projectFiles[0].NameTable) 
   $global:xpathNS.AddNamespace("ns", $global:projectFiles[0].DocumentElement.NamespaceURI)
   

--- a/ClangPowerTools/ClangPowerTools/clang-build.ps1
+++ b/ClangPowerTools/ClangPowerTools/clang-build.ps1
@@ -261,6 +261,7 @@ Set-Variable -name kVStudioDefaultPlatformToolset -Value "v141" -option Constant
 # Global variables
 
 [System.Collections.ArrayList] $global:FilesToDeleteWhenScriptQuits = @()
+[System.Collections.ArrayList] $global:ProjectSpecificVariables     = @()
 [Boolean]                      $global:FoundErrors                  = $false
 
 # current vcxproj and property sheets
@@ -304,6 +305,21 @@ Function Set-Var([parameter(Mandatory=$false)][string] $name,
 {
   Write-Debug "SET_VARIABLE $name : $value"
   Set-Variable -name $name -Value $value -Scope Global
+  
+  $global:ProjectSpecificVariables.Add($name) | Out-Null
+}
+
+Function Clear-Vars()
+{
+  Write-Debug "Clearing project specific variables"
+
+  foreach ($var in $global:ProjectSpecificVariables)
+  {
+    Write-Debug "  deleting $var"
+    Remove-Variable -name $var -scope Global
+  }
+
+  $global:ProjectSpecificVariables.Clear()
 }
 
 Function Write-Message([parameter(Mandatory=$true)][string] $msg
@@ -1534,6 +1550,11 @@ Function Process-Project( [Parameter(Mandatory=$true)][string]       $vcxprojPat
   # RUN CLANG JOBS
 
   Run-ClangJobs -clangJobs $clangJobs
+
+  #-----------------------------------------------------------------------------------------------
+  # CLEAN GLOBAL VARIABLES SPECIFIC TO CURRENT PROJECT
+
+  Clear-Vars
 }
  
 #-------------------------------------------------------------------------------------------------

--- a/ClangPowerTools/ClangPowerTools/clang-build.ps1
+++ b/ClangPowerTools/ClangPowerTools/clang-build.ps1
@@ -303,7 +303,7 @@ Function Fail-Script([parameter(Mandatory=$false)][string] $msg = "Got errors.")
 Function Set-Var([parameter(Mandatory=$false)][string] $name,
                  [parameter(Mandatory=$false)][string] $value)
 {
-  Write-Debug "SET_VAR $name : $value"
+  Write-Verbose "SET_VAR $name : $value"
   Set-Variable -name $name -Value $value -Scope Global
   
   $global:ProjectSpecificVariables.Add($name) | Out-Null
@@ -311,11 +311,11 @@ Function Set-Var([parameter(Mandatory=$false)][string] $name,
 
 Function Clear-Vars()
 {
-  Write-Debug "Clearing project specific variables"
+  Write-Verbose "Clearing project specific variables"
 
   foreach ($var in $global:ProjectSpecificVariables)
   {
-    Write-Debug "  DEL_VAR $var"
+    Write-Verbose "  DEL_VAR $var"
     Remove-Variable -name $var -scope Global
   }
 

--- a/ClangPowerTools/ClangPowerTools/clang-build.ps1
+++ b/ClangPowerTools/ClangPowerTools/clang-build.ps1
@@ -444,16 +444,17 @@ function Load-Solutions()
      $slnPath = $sln.FullName
      $global:slnFiles[$slnPath] = (Get-Content $slnPath)
    }
-   
+
    Write-Verbose-Array -array $global:slnFiles.Keys  -name "Solution file paths"
 }
 
 function Get-SolutionProjects($slnPath)
 {
   [string] $slnDirectory = Get-FileDirectory -file $slnPath
-  $matches = [regex]::Matches($global:slnFiles[$slnPath], 'Project\([{}\"A-Z0-9\-]+\) = \"[a-zA-Z0-9]+\", \"([\.A-Za-z0-9_\\\s]+)\"')
-  $projectAbsolutePaths = $matches | ForEach-Object { Canonize-Path -base $slnDirectory -child $_.Groups[1].Value -ignoreErrors } `
-                   | Where-Object { ! [string]::IsNullOrEmpty($_) }
+  $matches = [regex]::Matches($global:slnFiles[$slnPath], 'Project\([{}\"A-Z0-9\-]+\) = \S+,\s(\S+),')
+  $projectAbsolutePaths = $matches `
+    | ForEach-Object { Canonize-Path -base $slnDirectory -child $_.Groups[1].Value.Replace('"','') -ignoreErrors } `
+    | Where-Object { ! [string]::IsNullOrEmpty($_) }
   return $projectAbsolutePaths
 }
 

--- a/ClangPowerTools/ClangPowerTools/clang-build.ps1
+++ b/ClangPowerTools/ClangPowerTools/clang-build.ps1
@@ -262,8 +262,18 @@ Set-Variable -name kVStudioDefaultPlatformToolset -Value "v141" -option Constant
 #-------------------------------------------------------------------------------------------------
 # Global variables
 
+# temporary files created during project processing (e.g. PCH files)
 [System.Collections.ArrayList] $global:FilesToDeleteWhenScriptQuits = @()
+
+# vcxproj and property sheet files declare MsBuild properties (e.g. $(MYPROP)).
+# they are used in project xml nodes expressions. we have a 
+# translation engine (MSBUILD-POWERSHELL) for these. it relies on
+# PowerShell to evaluate these expressions. We have to inject project 
+# properties in the Powershell runtime context. We keep track of them in
+# this list, to be cleaned before the next project begins processing
 [System.Collections.ArrayList] $global:ProjectSpecificVariables     = @()
+
+# flag to signal when errors are encounteres during project processing
 [Boolean]                      $global:FoundErrors                  = $false
 
 # current vcxproj and property sheets

--- a/ClangPowerTools/ClangPowerTools/clang-build.ps1
+++ b/ClangPowerTools/ClangPowerTools/clang-build.ps1
@@ -889,6 +889,9 @@ function Select-ProjectNodes([Parameter(Mandatory=$true)]  [string][string] $xpa
       # handle corner cases when we have separators at beginning or at end
       $nodes[0].InnerText = ($nodes[0].InnerText -replace ";$", "")
       $nodes[0].InnerText = ($nodes[0].InnerText -replace "^;", "")
+
+      # we need to evaluate the expression to take properties into account
+      $nodes[0].InnerText = Evaluate-MSBuildExpression $nodes[0].InnerText
     } 
     return $nodes
   }

--- a/ClangPowerTools/ClangPowerTools/clang-build.ps1
+++ b/ClangPowerTools/ClangPowerTools/clang-build.ps1
@@ -749,8 +749,8 @@ Function Generate-Pch( [Parameter(Mandatory=$true)] [string]   $vcxprojPath
   return $stdafxPch
 }
 
-function Evaluate-MSBuildExpression([Parameter(Mandatory=$true)][string] $expression)
-{
+function Evaluate-MSBuildExpression([string] $expression)
+{  
   Write-Debug "Start evaluate MSBuild expression $expression"
 
   $msbuildToPsRules = (  ("([^a-zA-Z])=="    , '$1 -eq ' )`
@@ -782,7 +782,7 @@ function Evaluate-MSBuildExpression([Parameter(Mandatory=$true)][string] $expres
   {
     write-debug $_.Exception.Message
   }
-  
+
   Write-Debug "Evaluated expression to : $res"
 
   return $res

--- a/ClangPowerTools/ClangPowerTools/clang-build.ps1
+++ b/ClangPowerTools/ClangPowerTools/clang-build.ps1
@@ -170,7 +170,6 @@ Set-Variable -name kVcxprojXpathPropGroupElements `
              -value "/ns:Project/ns:PropertyGroup/*" `
              -option Constant
 
-Set-Variable -name kVStudioVarProjDir          -value '$(ProjectDir)'   -option Constant
 Set-Variable -name kVSDefaultWinSDK            -value '8.1'             -option Constant
 Set-Variable -name kVSDefaultWinSDK_XP         -value '7.0'             -option Constant
 
@@ -1176,17 +1175,10 @@ Function Get-ProjectAdditionalIncludes([Parameter(Mandatory=$true)][string] $vcx
   
   foreach ($token in $tokens)
   {
-    if ($token -eq $kVStudioVarProjDir)
+    [string] $includePath = Canonize-Path -base $projDir -child $token -ignoreErrors
+    if (![string]::IsNullOrEmpty($includePath))
     {
-      $projDir
-    }
-    Else
-    {
-      [string] $includePath = Canonize-Path -base $projDir -child $token -ignoreErrors
-      if (![string]::IsNullOrEmpty($includePath))
-      {
-        $includePath
-      }
+      $includePath
     }
   }
 }

--- a/ClangPowerTools/ClangPowerTools/clang-build.ps1
+++ b/ClangPowerTools/ClangPowerTools/clang-build.ps1
@@ -463,7 +463,7 @@ function Get-ProjectSolution()
   foreach ($slnPath in $global:slnFiles.Keys)
   {
     [string[]] $solutionProjectPaths = Get-SolutionProjects $slnPath
-    if ($solutionProjectPaths -and $solutionProjectPaths.Contains($global:vcxprojPath))
+    if ($solutionProjectPaths -and $solutionProjectPaths -contains $global:vcxprojPath)
     {
       return $slnPath
     }


### PR DESCRIPTION
Enables clang-build.ps1 to fully evaluate MSBuild expressions and conditions inside .vcxproj and .prop files.