### PR TITLE
No solution scanning for vs extension

### DIFF
--- a/ClangPowerTools/ClangPowerTools/Commands/CompileCommand.cs
+++ b/ClangPowerTools/ClangPowerTools/Commands/CompileCommand.cs
@@ -50,7 +50,6 @@ namespace ClangPowerTools
       {
         try
         {
-          LoadAllProjects();
           SaveActiveDocuments();
           CollectSelectedItems();
           RunScript(OutputWindowConstants.kComplileCommand);

--- a/ClangPowerTools/ClangPowerTools/Commands/TidyCommand.cs
+++ b/ClangPowerTools/ClangPowerTools/Commands/TidyCommand.cs
@@ -66,7 +66,6 @@ namespace ClangPowerTools
       {
         try
         {
-          LoadAllProjects();
           SaveActiveDocuments();
           CollectSelectedItems();
           mFileWatcher = new FileChangerWatcher();

--- a/ClangPowerTools/ClangPowerTools/Script/ScriptBuiler.cs
+++ b/ClangPowerTools/ClangPowerTools/Script/ScriptBuiler.cs
@@ -30,17 +30,15 @@ namespace ClangPowerTools
         ProjectItem projectItem = aItem.GetObject() as ProjectItem;
         parentDirectoryPath = new DirectoryInfo(projectItem.ContainingProject.FullName).Parent.FullName;
         string containingProject = projectItem.ContainingProject.FullName;
-        script = $"{script} {ScriptConstants.kProject} ''{containingProject}'' {ScriptConstants.kFile} {projectItem.Name} " +
-          $"{ScriptConstants.kActiveConfiguration} ''{ProjectConfiguration.GetConfiguration(projectItem.ContainingProject)}|{ProjectConfiguration.GetPlatform(projectItem.ContainingProject)}''";
+        script = $"{script} {ScriptConstants.kProject} ''{containingProject}'' " +
+          $"{ScriptConstants.kFile} {projectItem.Name} {ScriptConstants.kActiveConfiguration} " +
+          $"''{ProjectConfiguration.GetConfiguration(projectItem.ContainingProject)}|{ProjectConfiguration.GetPlatform(projectItem.ContainingProject)}''";
       }
       else if (aItem is SelectedProject)
       {
         Project project = aItem.GetObject() as Project;
         parentDirectoryPath = new DirectoryInfo(project.FullName).Parent.FullName;
-
-        var projPath = project.FullName;
-
-        script = $"{script} {ScriptConstants.kProject} ''{projPath}'' {ScriptConstants.kActiveConfiguration} " +
+        script = $"{script} {ScriptConstants.kProject} ''{project.FullName}'' {ScriptConstants.kActiveConfiguration} " +
           $"''{ProjectConfiguration.GetConfiguration(project)}|{ProjectConfiguration.GetPlatform(project)}''";
       }
       parentDirectoryPath = GetCommandPath(aSolutionPath, parentDirectoryPath);
@@ -123,17 +121,22 @@ namespace ClangPowerTools
       return parameters;
     }
 
-    public string GetCommandPath(string aFirstPath, string aSecondPath)
+    private string GetCommandPath(string aFirstPath, string aSecondPath)
     {
-      var paths = new List<string>() { aFirstPath, aSecondPath };
+      var firstPath = aFirstPath.ToLower().Split(new char[] { '/', '\\' });
+      var secondPath = aSecondPath.ToLower().Split(new char[] { '/', '\\' });
+      var length = firstPath.Length < secondPath.Length ? firstPath.Length : secondPath.Length;
 
-      var matchingChars =
-            from len in Enumerable.Range(0, paths.Min(s => s.Length)).Reverse()
-            let possibleMatch = paths.First().Substring(0, len)
-            where paths.All(f => f.StartsWith(possibleMatch))
-            select possibleMatch;
-
-      return Path.GetDirectoryName(matchingChars.First());
+      var path = new List<string>();
+      for (int index = 0; index < length - 1; ++index)
+      {
+        if (0 != firstPath[index].CompareTo(secondPath[index]))
+          break;
+        if (0 == index)
+          firstPath[index] += "\\";
+        path.Add(firstPath[index]);
+      }
+      return Path.Combine(path.ToArray());
     }
 
     #endregion

--- a/ClangPowerTools/ClangPowerTools/clang-build.ps1
+++ b/ClangPowerTools/ClangPowerTools/clang-build.ps1
@@ -8,9 +8,8 @@
     One or more of these projects will be compiled or tidied up (modernized), using Clang.
 
 .PARAMETER aSolutionsPath
-    Alias 'dir'. Source directory to find sln files. Projects will be extracted from each sln.
-    Important: Solutions must be reachable, recursively,
-               in this directory. Otherwise, they won't be processed.
+    Alias 'dir'. Source directory to find sln files. 
+                 Projects will be extracted from each sln.
     
     Important: You can pass an absolute path to a sln. This way, no file searching will be done, and
                only the projects from this solution file will be taken into acount.

--- a/ClangPowerTools/ClangPowerTools/clang-build.ps1
+++ b/ClangPowerTools/ClangPowerTools/clang-build.ps1
@@ -1724,7 +1724,17 @@ Function Process-Project( [Parameter(Mandatory=$true)][string]       $vcxprojPat
   }
   else
   {
-    Write-Verbose ("PCH directory: $stdafxDir")
+    # pch generation crashes on VS 15.5
+    [string] $mscVer = Get-MscVer -visualStudioPath $vsPath
+    if ($mscVer -eq "14.12.25827")
+    {
+      Write-Verbose "IMPORTANT: PCH disabled on VS 2017.5 (MscVer $mscVer) until compatibility issues are resolved :("
+      $stdafxDir = ""
+    }
+    else
+    {
+      Write-Verbose ("PCH directory: $stdafxDir")
+    }
   }
   #-----------------------------------------------------------------------------------------------
   # DETECT PROJECT PREPROCESSOR DEFINITIONS

--- a/ClangPowerTools/ClangPowerTools/clang-build.ps1
+++ b/ClangPowerTools/ClangPowerTools/clang-build.ps1
@@ -1515,6 +1515,7 @@ Function Get-CompileCallArguments( [Parameter(Mandatory=$false)][string[]] $prep
 }
 
 Function Get-TidyCallArguments( [Parameter(Mandatory=$false)][string[]] $preprocessorDefinitions
+                              , [Parameter(Mandatory=$false)][string[]] $forceIncludeFiles
                               , [Parameter(Mandatory=$true)][string]   $fileToTidy
                               , [Parameter(Mandatory=$false)][switch]  $fix)
 {
@@ -1545,6 +1546,16 @@ Function Get-TidyCallArguments( [Parameter(Mandatory=$false)][string[]] $preproc
   $tidyArgs += @(Get-ClangCompileFlags)
   $tidyArgs += $preprocessorDefinitions
 
+  if ($forceIncludeFiles)
+  {
+    $tidyArgs += $kClangFlagNoMsInclude;
+    
+    foreach ($file in $forceIncludeFiles)
+    {
+      $tidyArgs += "$kClangFlagForceInclude $file"
+    }
+  }
+
   return $tidyArgs
 }
 
@@ -1562,8 +1573,10 @@ Function Get-ExeCallArguments( [Parameter(Mandatory=$true) ][string]       $vcxp
                                               -pchFilePath             $pchFilePath `
                                               -fileToCompile           $currentFile }
     Tidy    { return Get-TidyCallArguments -preprocessorDefinitions $preprocessorDefinitions `
+                                           -forceIncludeFiles       $forceIncludeFiles `
                                            -fileToTidy              $currentFile }
     TidyFix { return Get-TidyCallArguments -preprocessorDefinitions $preprocessorDefinitions `
+                                           -forceIncludeFiles       $forceIncludeFiles `
                                            -fileToTidy              $currentFile `
                                            -fix}
   }


### PR DESCRIPTION
When in VS Extension, the fully qualified solution name is known.

Solution scanning in the source directory should be done only in CLI automation scenarios.