### PR TITLE
Create dedicated option page for custom checks

### DIFF
--- a/ClangPowerTools/ClangPowerTools/ClangPowerTools.csproj
+++ b/ClangPowerTools/ClangPowerTools/ClangPowerTools.csproj
@@ -99,6 +99,9 @@
     <Compile Include="PCHParser.cs" />
     <Compile Include="ProjectConfiguration.cs" />
     <Compile Include="Script\RunningProcesses.cs" />
+    <Compile Include="ConfigurationPage.cs">
+      <SubType>Component</SubType>
+    </Compile>
     <Compile Include="SettingsPathBuilder.cs" />
     <Compile Include="SilentFileChanger\SilentFileChangerEqualityComparer.cs" />
     <Compile Include="Items\IItem.cs" />

--- a/ClangPowerTools/ClangPowerTools/ClangPowerTools.csproj
+++ b/ClangPowerTools/ClangPowerTools/ClangPowerTools.csproj
@@ -82,6 +82,9 @@
     <Compile Include="Commands\CommandsController.cs" />
     <Compile Include="Commands\CompileCommand.cs" />
     <Compile Include="DialogPages\DefaultOptions.cs" />
+    <Compile Include="DialogPages\TidyCustomChecks.cs">
+      <SubType>Component</SubType>
+    </Compile>
     <Compile Include="Error\ErrorParser.cs" />
     <Compile Include="Error\ErrorParserConstants.cs" />
     <Compile Include="Error\ErrorsManager.cs" />

--- a/ClangPowerTools/ClangPowerTools/ClangPowerToolsPackage.cs
+++ b/ClangPowerTools/ClangPowerTools/ClangPowerToolsPackage.cs
@@ -4,6 +4,7 @@ using System.Runtime.InteropServices;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using ClangPowerTools.Commands;
+using ClangPowerTools.DialogPages;
 
 namespace ClangPowerTools
 {
@@ -31,6 +32,7 @@ namespace ClangPowerTools
   [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1650:ElementDocumentationMustBeSpelledCorrectly", Justification = "pkgdef, VS and vsixmanifest are valid VS terms")]
   [ProvideOptionPage(typeof(GeneralOptions), "Clang Power Tools", "General", 0, 0, true)]
   [ProvideOptionPage(typeof(TidyOptions), "Clang Power Tools\\Tidy", "Options", 0, 0, true)]
+  [ProvideOptionPage(typeof(TidyCustomChecks), "Clang Power Tools\\Tidy", "Custom Checks", 0, 0, true)]
   [ProvideOptionPage(typeof(TidyChecks), "Clang Power Tools\\Tidy", "Predefined Checks", 0, 0, true)]
   [ProvideAutoLoad(UIContextGuids80.SolutionExists)]
   public sealed class RunClangPowerToolsPackage : Package

--- a/ClangPowerTools/ClangPowerTools/ClangTidyOptions.cs
+++ b/ClangPowerTools/ClangPowerTools/ClangTidyOptions.cs
@@ -6,12 +6,6 @@ namespace ClangPowerTools
   [Serializable]
   public class ClangTidyOptions
   {
-    #region Members
-
-    private List<string> mTidyChecks = new List<string>();
-
-    #endregion
-
     #region Properties
 
     public List<string> TidyChecks { get; set; } = new List<string>();

--- a/ClangPowerTools/ClangPowerTools/Commands/ClangCommand.cs
+++ b/ClangPowerTools/ClangPowerTools/Commands/ClangCommand.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using ClangPowerTools.DialogPages;
 using Microsoft.VisualStudio.Shell;
 
 namespace ClangPowerTools
@@ -57,11 +58,11 @@ namespace ClangPowerTools
 
     #region Protected methods
 
-    protected void RunScript(string aCommandName, TidyOptions mTidyOptions = null, TidyChecks mTidyChecks = null)
+    protected void RunScript(string aCommandName, TidyOptions mTidyOptions = null, TidyChecks mTidyChecks = null, TidyCustomChecks mTidyCustomChecks = null)
     {
       mScriptBuilder = new ScriptBuiler();
       mScriptBuilder.ConstructParameters(mGeneralOptions, mTidyOptions, mTidyChecks,
-        DTEObj, VsEdition, VsVersion);
+        mTidyCustomChecks, DTEObj, VsEdition, VsVersion);
 
       string solutionPath = DTEObj.Solution.FullName;
 

--- a/ClangPowerTools/ClangPowerTools/Commands/TidyCommand.cs
+++ b/ClangPowerTools/ClangPowerTools/Commands/TidyCommand.cs
@@ -4,6 +4,7 @@ using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using EnvDTE;
 using System.IO;
+using ClangPowerTools.DialogPages;
 
 namespace ClangPowerTools
 {
@@ -16,6 +17,7 @@ namespace ClangPowerTools
 
     private TidyOptions mTidyOptions;
     private TidyChecks mTidyChecks;
+    private TidyCustomChecks mTidyCustomChecks;
     private FileChangerWatcher mFileWatcher;
     private FileOpener mFileOpener;
 
@@ -33,6 +35,8 @@ namespace ClangPowerTools
     {
       mTidyOptions = (TidyOptions)Package.GetDialogPage(typeof(TidyOptions));
       mTidyChecks = (TidyChecks)Package.GetDialogPage(typeof(TidyChecks));
+      mTidyCustomChecks = (TidyCustomChecks)Package.GetDialogPage(typeof(TidyCustomChecks));
+
       mFileOpener = new FileOpener(DTEObj);
       if (ServiceProvider.GetService(typeof(IMenuCommandService)) is OleMenuCommandService commandService)
       {
@@ -73,7 +77,7 @@ namespace ClangPowerTools
               WatchFiles();
               SilentFiles(guard);
             }
-            RunScript(OutputWindowConstants.kTidyCodeCommand, mTidyOptions, mTidyChecks);
+            RunScript(OutputWindowConstants.kTidyCodeCommand, mTidyOptions, mTidyChecks, mTidyCustomChecks);
           }
         }
         catch (Exception exception)

--- a/ClangPowerTools/ClangPowerTools/ConfigurationPage.cs
+++ b/ClangPowerTools/ClangPowerTools/ConfigurationPage.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.VisualStudio.Shell;
+using System.IO;
+
+namespace ClangPowerTools
+{
+  public class ConfigurationPage<TSettings> : DialogPage  where TSettings : new()
+  {
+    protected TSettings LoadFromFile(string aFilePath)
+    {
+      XmlSerializer serializer = new XmlSerializer();
+
+      var config = File.Exists(aFilePath)
+        ? serializer.DeserializeFromFIle<TSettings>(aFilePath)
+        : new TSettings();
+
+      return config;
+    }
+
+    protected void SaveToFile(string aFilePath, TSettings config)
+    {
+      XmlSerializer serializer = new XmlSerializer();
+      serializer.SerializeToFile(aFilePath, config);
+    }
+
+  }
+}

--- a/ClangPowerTools/ClangPowerTools/DialogPages/GeneralOptions.cs
+++ b/ClangPowerTools/ClangPowerTools/DialogPages/GeneralOptions.cs
@@ -1,14 +1,12 @@
-﻿using Microsoft.VisualStudio.Shell;
-using System;
+﻿using System;
 using System.ComponentModel;
-using System.IO;
 using System.Linq;
 using System.Web.UI.WebControls;
 
 namespace ClangPowerTools
 {
   [Serializable]
-  public class GeneralOptions : DialogPage
+  public class GeneralOptions : ConfigurationPage<ClangOptions>
   {
     #region Members
 
@@ -64,7 +62,7 @@ namespace ClangPowerTools
     {
       string path = mSettingsPathBuilder.GetPath(kGeneralSettingsFileName);
 
-      var currentSettings = new ClangOptions
+      var updatedConfig = new ClangOptions
       {
         ProjectsToIgnore = this.ProjectsToIgnore.ToList(),
         FilesToIgnore = this.FilesToIgnore.ToList(),
@@ -73,26 +71,22 @@ namespace ClangPowerTools
         VerboseMode = this.VerboseMode,
         ClangFlags = this.ClangFlags.ToList()
       };
-
-      XmlSerializer serializer = new XmlSerializer();
-      serializer.SerializeToFile(path, currentSettings);
+      SaveToFile(path, updatedConfig);
     }
 
     public override void LoadSettingsFromStorage()
     {
       string path = mSettingsPathBuilder.GetPath(kGeneralSettingsFileName);
+
       XmlSerializer serializer = new XmlSerializer();
+      var loadedConfig = LoadFromFile(path);
 
-      var savedConfig = File.Exists(path)
-        ? serializer.DeserializeFromFIle<ClangOptions>(path)
-        : new ClangOptions();
-
-      this.ProjectsToIgnore = savedConfig.ProjectsToIgnore.ToArray();
-      this.FilesToIgnore = savedConfig.FilesToIgnore.ToArray();
-      this.Continue = savedConfig.Continue;
-      this.TreatWarningsAsErrors = savedConfig.TreatWarningsAsErrors;
-      this.VerboseMode = savedConfig.VerboseMode;
-      this.ClangFlags = savedConfig.ClangFlags.ToArray();
+      this.ProjectsToIgnore = loadedConfig.ProjectsToIgnore.ToArray();
+      this.FilesToIgnore = loadedConfig.FilesToIgnore.ToArray();
+      this.Continue = loadedConfig.Continue;
+      this.TreatWarningsAsErrors = loadedConfig.TreatWarningsAsErrors;
+      this.VerboseMode = loadedConfig.VerboseMode;
+      this.ClangFlags = loadedConfig.ClangFlags.ToArray();
     }
 
     #endregion

--- a/ClangPowerTools/ClangPowerTools/DialogPages/TidyCustomChecks.cs
+++ b/ClangPowerTools/ClangPowerTools/DialogPages/TidyCustomChecks.cs
@@ -1,0 +1,89 @@
+﻿using Microsoft.VisualStudio.Shell;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Web.UI.WebControls;
+
+namespace ClangPowerTools.DialogPages
+{
+  public class TidyCustomChecks : DialogPage
+  {
+    #region Members
+
+    private string[] mTidyChecks;
+    private const string kTidyOptionsFileName = "TidyOptionsConfiguration.config";
+    private SettingsPathBuilder mSettingsPathBuilder = new SettingsPathBuilder();
+
+    #endregion
+
+    #region Properties
+
+    [Category(" Tidy")]
+    [DisplayName("Custom Checks")]
+    [Description("Specify clang-tidy checks to run using the standard tidy syntax. You can use wildcards to match multiple checks, combine them, etc (Eg. \"modernize-*, readability-*\").")]
+    [TypeConverter(typeof(StringArrayConverter))]
+    public string[] TidyChecks
+    {
+      get => mTidyChecks;
+      set => mTidyChecks = value;
+    }
+
+    [Browsable(false)]
+    [Category(" Tidy")]
+    [DisplayName("Fix")]
+    [Description("Automatically applies clang-tidy fixes to selected source files, affected header files and saves them to disk.")]
+    public bool Fix { get; set; }
+
+    [Browsable(false)]
+    [Category(" Tidy")]
+    [DisplayName("Use checks from")]
+    [Description("Tidy checks: switch between explicitly specified checks (predefined or custom) and using checks from .clang-tidy configuration files.\nOther options are always loaded from .clang-tidy files.")]
+    [TypeConverter(typeof(TidyModeConvertor))]
+    public string TidyMode { get; set; }
+
+    #endregion
+
+    #region DialogPage Save and Load implementation 
+
+    public override void SaveSettingsToStorage()
+    {
+      string path = mSettingsPathBuilder.GetPath(kTidyOptionsFileName);
+
+      var currentSettings = new ClangTidyOptions
+      {
+        Fix = this.Fix,
+        TidyChecks = this.TidyChecks.ToList(),
+        TidyMode = this.TidyMode
+      };
+
+      XmlSerializer serializer = new XmlSerializer();
+      serializer.SerializeToFile(path, currentSettings);
+    }
+
+    public override void LoadSettingsFromStorage()
+    {
+      string path = mSettingsPathBuilder.GetPath(kTidyOptionsFileName);
+      XmlSerializer serializer = new XmlSerializer();
+
+      var loadedConfig = File.Exists(path)
+        ? serializer.DeserializeFromFIle<ClangTidyOptions>(path)
+        : new ClangTidyOptions();
+
+      this.TidyChecks = loadedConfig.TidyChecks.ToArray();
+      this.Fix = loadedConfig.Fix;
+
+      if (null == loadedConfig.TidyMode || string.Empty == loadedConfig.TidyMode)
+        this.TidyMode = (0 == this.TidyChecks.Length ? TidyModeConstants.kPredefinedChecks : TidyModeConstants.kCustomChecks);
+      else
+        this.TidyMode = loadedConfig.TidyMode;
+    }
+
+    #endregion
+
+
+  }
+}

--- a/ClangPowerTools/ClangPowerTools/DialogPages/TidyOptions.cs
+++ b/ClangPowerTools/ClangPowerTools/DialogPages/TidyOptions.cs
@@ -1,34 +1,19 @@
-﻿using Microsoft.VisualStudio.Shell;
-using System;
+﻿using System;
 using System.ComponentModel;
-using System.IO;
-using System.Linq;
-using System.Web.UI.WebControls;
 
 namespace ClangPowerTools
 {
   [Serializable]
-  public class TidyOptions : DialogPage
+  public class TidyOptions : ConfigurationPage<ClangTidyOptions>
   {
     #region Members
 
-    private string[] mTidyChecks;
     private const string kTidyOptionsFileName = "TidyOptionsConfiguration.config";
     private SettingsPathBuilder mSettingsPathBuilder = new SettingsPathBuilder();
 
     #endregion
 
     #region Properties
-
-    [Category(" Tidy")]
-    [DisplayName("Custom Checks")]
-    [Description("Specify clang-tidy checks to run using the standard tidy syntax. You can use wildcards to match multiple checks, combine them, etc (Eg. \"modernize-*, readability-*\").")]
-    [TypeConverter(typeof(StringArrayConverter))]
-    public string[] TidyChecks
-    {
-      get => mTidyChecks;
-      set => mTidyChecks = value;
-    }
 
     [Category(" Tidy")]
     [DisplayName("Fix")]
@@ -49,31 +34,21 @@ namespace ClangPowerTools
     {
       string path = mSettingsPathBuilder.GetPath(kTidyOptionsFileName);
 
-      var currentSettings = new ClangTidyOptions
-      {
-        Fix = this.Fix,
-        TidyChecks = this.TidyChecks.ToList(),
-        TidyMode = this.TidyMode
-      };
+      var updatedConfig = LoadFromFile(path);
+      updatedConfig.Fix = this.Fix;
+      updatedConfig.TidyMode = this.TidyMode;
 
-      XmlSerializer serializer = new XmlSerializer();
-      serializer.SerializeToFile(path, currentSettings);
+      SaveToFile(path, updatedConfig);
     }
 
     public override void LoadSettingsFromStorage()
     {
       string path = mSettingsPathBuilder.GetPath(kTidyOptionsFileName);
-      XmlSerializer serializer = new XmlSerializer();
+      var loadedConfig = LoadFromFile(path);
 
-      var loadedConfig = File.Exists(path)
-        ? serializer.DeserializeFromFIle<ClangTidyOptions>(path)
-        : new ClangTidyOptions();
-
-      this.TidyChecks = loadedConfig.TidyChecks.ToArray();
       this.Fix = loadedConfig.Fix;
-
       if (null == loadedConfig.TidyMode || string.Empty == loadedConfig.TidyMode)
-        this.TidyMode = (0 == this.TidyChecks.Length ? TidyModeConstants.kPredefinedChecks : TidyModeConstants.kCustomChecks);
+        this.TidyMode = (0 == loadedConfig.TidyChecks.Count ? TidyModeConstants.kPredefinedChecks : TidyModeConstants.kCustomChecks);
       else
         this.TidyMode = loadedConfig.TidyMode;
     }

--- a/ClangPowerTools/ClangPowerTools/Script/ScriptBuiler.cs
+++ b/ClangPowerTools/ClangPowerTools/Script/ScriptBuiler.cs
@@ -1,4 +1,5 @@
-﻿using EnvDTE;
+﻿using ClangPowerTools.DialogPages;
+using EnvDTE;
 using EnvDTE80;
 using System;
 using System.ComponentModel;
@@ -40,11 +41,11 @@ namespace ClangPowerTools
     }
 
     public void ConstructParameters(GeneralOptions aGeneralOptions, TidyOptions aTidyOptions, 
-      TidyChecks aTidyChecks, DTE2 aDte, string aVsEdition, string aVsVersion)
+      TidyChecks aTidyChecks, TidyCustomChecks aTidyCustomChecks, DTE2 aDte, string aVsEdition, string aVsVersion)
     {
       mParameters = GetGeneralParameters(aGeneralOptions);
       mParameters = null != aTidyOptions ?
-        $"{mParameters} {GetTidyParameters(aTidyOptions, aTidyChecks)}" : $"{mParameters} {ScriptConstants.kParallel}";
+        $"{mParameters} {GetTidyParameters(aTidyOptions, aTidyChecks, aTidyCustomChecks)}" : $"{mParameters} {ScriptConstants.kParallel}";
       mParameters = $"{mParameters} {ScriptConstants.kVsVersion} {aVsVersion} {ScriptConstants.kVsEdition} {aVsEdition}";
     }
 
@@ -85,7 +86,7 @@ namespace ClangPowerTools
       return $"{parameters}";
     }
 
-    private string GetTidyParameters(TidyOptions aTidyOptions, TidyChecks aTidyChecks)
+    private string GetTidyParameters(TidyOptions aTidyOptions, TidyChecks aTidyChecks, TidyCustomChecks aTidyCustomChecks)
     {
       string parameters = string.Empty;
 
@@ -95,7 +96,7 @@ namespace ClangPowerTools
       }
       else if (TidyModeConstants.kCustomChecks == aTidyOptions.TidyMode)
       {
-        parameters = $",{String.Join(",", aTidyOptions.TidyChecks)}";
+        parameters = $",{String.Join(",", aTidyCustomChecks.TidyChecks)}";
       }
       else
       {

--- a/ClangPowerTools/ClangPowerTools/XmlSerializer.cs
+++ b/ClangPowerTools/ClangPowerTools/XmlSerializer.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.IO;
 using NetSerializer = System.Xml.Serialization.XmlSerializer;
 
 namespace ClangPowerTools


### PR DESCRIPTION
Split Option page in Custom Checks and Options. Created a dedicated option page for Custom Checks and keeps the previews behavior saving both configuration pages in one file.