### PR TITLE
Trim whitespace from #include paths

### DIFF
--- a/ClangPowerTools/ClangPowerTools/clang-build.ps1
+++ b/ClangPowerTools/ClangPowerTools/clang-build.ps1
@@ -858,10 +858,10 @@ Function Get-VisualStudio-Path()
 
 Function Get-ProjectIncludeDirectories([Parameter(Mandatory=$false)][string] $stdafxDir)
 {
-  [string[]] $returnArray = ($IncludePath -split ";")                                                  | `
-                            Where-Object { ![string]::IsNullOrEmpty($_) }                              | `
-                            ForEach-Object { Canonize-Path -base $ProjectDir -child $_ -ignoreErrors } | `
-                            Where-Object { ![string]::IsNullOrEmpty($_) }                              | `
+  [string[]] $returnArray = ($IncludePath -split ";")                                                         | `
+                            Where-Object { ![string]::IsNullOrWhiteSpace($_) }                                | `
+                            ForEach-Object { Canonize-Path -base $ProjectDir -child $_.Trim() -ignoreErrors } | `
+                            Where-Object { ![string]::IsNullOrEmpty($_) }                                     | `
                             ForEach-Object { $_ -replace '\\$', '' }                                   
   if ($env:CPT_LOAD_ALL -eq '1')
   {
@@ -1682,12 +1682,12 @@ Function Get-ProjectAdditionalIncludes()
   
   foreach ($token in $tokens)
   {
-    if ([string]::IsNullOrEmpty($token))
+    if ([string]::IsNullOrWhiteSpace($token))
     {
       continue
     }
     
-    [string] $includePath = Canonize-Path -base $ProjectDir -child $token -ignoreErrors
+    [string] $includePath = Canonize-Path -base $ProjectDir -child $token.Trim() -ignoreErrors
     if (![string]::IsNullOrEmpty($includePath))
     {
       $includePath -replace '\\$', ''


### PR DESCRIPTION
`String::IsNullOrWhiteSpace` and `String::IsNullOrEmpty` return `true` when called on `null` or `String.Empty`. `String::IsNullOrWhiteSpace` also returns `true` on a `String` filled with white-space characters; after applying `.Trim()`, `Canonize-Path` should be called with a proper `-child`. 

Should solve #254.
Also takes care of `<Project><PropertyGroup><IncludePath>` paths.
