### PR TITLE
Allow white spaces in project name and path

### DIFF
--- a/ClangPowerTools/ClangPowerTools/clang-build.ps1
+++ b/ClangPowerTools/ClangPowerTools/clang-build.ps1
@@ -562,7 +562,7 @@ function Load-Solutions()
 function Get-SolutionProjects([Parameter(Mandatory=$true)][string] $slnPath)
 {
   [string] $slnDirectory = Get-FileDirectory -file $slnPath
-  $matches = [regex]::Matches($global:slnFiles[$slnPath], 'Project\([{}\"A-Z0-9\-]+\) = \S+,\s(\S+),')
+  $matches = [regex]::Matches($global:slnFiles[$slnPath], 'Project\([{}\"A-Z0-9\-]+\) = \".*?\",\s\"(.*?)\"')
   $projectAbsolutePaths = $matches `
     | ForEach-Object { Canonize-Path -base $slnDirectory `
                                      -child $_.Groups[1].Value.Replace('"','') -ignoreErrors } `


### PR DESCRIPTION
Modified regular expression to allow white spaces in project name and path.
Logic of regular expression changed from looking strings to especially look for project path.