### PR TITLE
Support for custom Clang "bin" directory

### DIFF
--- a/ClangPowerTools/ClangPowerTools/DialogOptions/ClangOptions.cs
+++ b/ClangPowerTools/ClangPowerTools/DialogOptions/ClangOptions.cs
@@ -32,6 +32,8 @@ namespace ClangPowerTools
 
     public string Version { get; set; }
 
+    public string ClangBinDirectory { get; set; }
+
     #endregion
 
 

--- a/ClangPowerTools/ClangPowerTools/DialogPages/GeneralOptions.cs
+++ b/ClangPowerTools/ClangPowerTools/DialogPages/GeneralOptions.cs
@@ -1,8 +1,10 @@
 ﻿using ClangPowerTools.Convertors;
 using System;
 using System.ComponentModel;
+using System.Drawing.Design;
 using System.Linq;
 using System.Web.UI.WebControls;
+using System.Windows.Forms.Design;
 
 namespace ClangPowerTools
 {
@@ -67,6 +69,12 @@ namespace ClangPowerTools
     [Description("Automatically run Clang compile on the current source file, after successful MSVC compilation.")]
     public bool ClangCompileAfterVsCompile { get; set; }
 
+    [Category("General")]
+    [DisplayName("Path to the Clang \"bin\" directory")]
+    [Description("Use only if the Clang binaries are not in %PATH% and you are not able to install in the default \"LLVM\" directory from \"Program Files\".")]
+    [Editor(typeof(FolderNameEditor), typeof(UITypeEditor))]
+    public string ClangBinDirectory { get; set; }
+
     [Browsable(false)]
     public string Version { get; set; }
 
@@ -88,6 +96,7 @@ namespace ClangPowerTools
         VerboseMode = this.VerboseMode,
         ClangFlags = this.ClangFlags.ToList(),
         ClangCompileAfterVsCompile = this.ClangCompileAfterVsCompile,
+        ClangBinDirectory = this.ClangBinDirectory,
         Version = this.Version
       };
 
@@ -111,6 +120,8 @@ namespace ClangPowerTools
 
       this.VerboseMode = loadedConfig.VerboseMode;
       this.ClangFlags = loadedConfig.ClangFlags.ToArray();
+
+      this.ClangBinDirectory = loadedConfig.ClangBinDirectory;
 
       this.ClangCompileAfterVsCompile = loadedConfig.ClangCompileAfterVsCompile;
       this.Version = loadedConfig.Version;

--- a/ClangPowerTools/ClangPowerTools/Script/ClangCompileTidyScript.cs
+++ b/ClangPowerTools/ClangPowerTools/Script/ClangCompileTidyScript.cs
@@ -87,6 +87,9 @@ namespace ClangPowerTools.Script
       if (0 == string.Compare(aGeneralOptions.AdditionalIncludes, ComboBoxConstants.kSystemIncludeDirectories))
         parameters = $"{parameters} {ScriptConstants.kSystemIncludeDirectories}";
 
+      if (!string.IsNullOrWhiteSpace(aGeneralOptions.ClangBinDirectory))
+        parameters = $"{parameters} {ScriptConstants.kClangBinDirectory} ''{aGeneralOptions.ClangBinDirectory}''";
+
       return $"{parameters}";
     }
 

--- a/ClangPowerTools/ClangPowerTools/Script/ScriptConstants.cs
+++ b/ClangPowerTools/ClangPowerTools/Script/ScriptConstants.cs
@@ -36,6 +36,7 @@ namespace ClangPowerTools
     public const string kTidy = "-tidy";
     public const string kTidyFix = "-tidy-fix";
 
+    public const string kClangBinDirectory = "-clang-bin-dir";
     public const string kClangFlags = "-clang-flags";
     public const string kIncludeDirectores = "-include-dirs";
     public const string kProjectsToIgnore = "-proj-ignore"; 


### PR DESCRIPTION
Proposal for #199.

If the Clang binaries are not in %PATH% and if Clang cannot be installed in "Program Files" due to missing rights, the user can manually specify the location of the Clang "bin" directory in the "General" section of the plugin settings page.

When specified, this path is transmitted to the PowerShell script via the "-clang-bin-dir" parameter.

The script will search for the Clang binaries in the following order:
- %PATH%
- the manual Clang "bin" directory override (the "-clang-bin-dir" parameter, if present)
- %ProgramW6432%\LLVM\bin (64-bit Clang default installed on 64-bit Windows)
- %ProgramFiles(x86)%\LLVM\bin (32-bit Clang default installed on 64-bit Windows)