### PR TITLE
Integration with vc++ packaging tool (user wide type)

### DIFF
--- a/ClangPowerTools/ClangPowerTools/clang-build.ps1
+++ b/ClangPowerTools/ClangPowerTools/clang-build.ps1
@@ -324,8 +324,19 @@ Set-Variable -name "kMsbuildExpressionToPsRules" -option Constant         `
       , ("Exists\((.*?)\)(\s|$)"           , '(Exists($1))$2'            )`
       , ("HasTrailingSlash\((.*?)\)(\s|$)" , '(HasTrailingSlash($1))$2'  )`
       , ("(\`$\()(Registry:)(.*?)(\))"     , '$$(GetRegValue("$3"))'     )`
-      , ("\[MSBuild\]::GetDirectoryNameOfFileAbove\((.+?),\s*`"?'?(.+?)(`"|')\)+",
-         'GetDirNameOfFileAbove -startDir $1 -targetFile ''$2'')'        )`
+
+	  <# for cases with ' or ", like: #>
+      <# $([MSBuild]::GetDirectoryNameOfFileAbove(_, 'file') #>
+      <# $([MSBuild]::GetDirectoryNameOfFileAbove(_, "file") #>
+      , ("\[MSBuild\]::GetDirectoryNameOfFileAbove\((.+?),\s*`"?'?(.+?)(`"|')\)", `
+       'GetDirNameOfFileAbove -startDir $1 -targetFile ''$2''' )`
+      <# for cases without ' and ", like: #>
+      <# $([MSBuild]::GetDirectoryNameOfFileAbove(_, file) #>
+      <# $([MSBuild]::GetDirectoryNameOfFileAbove(_, $(file))' #>
+      , ("\[MSBuild\]::GetDirectoryNameOfFileAbove\((.+?),\s*((|.+)?)\)\)", `
+       'GetDirNameOfFileAbove -startDir $1 -targetFile ''$2'' )' )`
+
+      , ("\`$\(LOCALAPPDATA\)"                 , '$env:LOCALAPPDATA' )`
                        )
 
 Set-Variable -name "kMsbuildConditionToPsRules" -option Constant `


### PR DESCRIPTION
Integration with [VC++ Packaging Tool](https://github.com/Microsoft/vcpkg) - only user-wide options (vcpkg integrate install)

It reads "C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\V140\ImportBefore\Default" props and add it to vcxproj xml during LoadProject.
In particual, there is 'vcpkg.system.props'.