### PR TITLE
Make VisualStudio SKU optional

### DIFF
--- a/ClangPowerTools/ClangPowerTools/clang-build.ps1
+++ b/ClangPowerTools/ClangPowerTools/clang-build.ps1
@@ -107,6 +107,8 @@
       Alias 'vs-sku'. Sku of Visual Studio (VC++) installed and that'll be used for
       standard library include directories. E.g. Professional.
 
+      This option is mandatory only if multiple Sku instances with the same version can be found
+
 .NOTES
     Author: Gabriel Diaconita
 #>
@@ -126,7 +128,7 @@ param( [alias("dir")]          [Parameter(Mandatory=$true)] [string]   $aSolutio
      , [alias("header-filter")][Parameter(Mandatory=$false)][string]   $aTidyHeaderFilter
      , [alias("format-style")] [Parameter(Mandatory=$false)][string]   $aAfterTidyFixFormatStyle
      , [alias("vs-ver")]       [Parameter(Mandatory=$true)] [string]   $aVisualStudioVersion
-     , [alias("vs-sku")]       [Parameter(Mandatory=$true)] [string]   $aVisualStudioSku
+     , [alias("vs-sku")]       [Parameter(Mandatory=$false)][string]   $aVisualStudioSku
      )
 
 # System Architecture Constants
@@ -859,11 +861,12 @@ Function Get-VisualStudio-Path()
   {
     if (Test-Path $kVsWhereLocation)
     {
-      [string] $product = "Microsoft.VisualStudio.Product.$aVisualStudioSku"
+      [string] $product = If ([string]::IsNullOrEmpty($aVisualStudioSku)) { "*" } Else { "Microsoft.VisualStudio.Product.$aVisualStudioSku" } # Specific version set? Use that one. Else, pick the only available one
       return (& "$kVsWhereLocation" -nologo `
                                     -property installationPath `
                                     -products $product `
-                                    -prerelease)
+                                    -prerelease `
+                                    -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64)
     }
 
     if (Test-Path -Path $kVs15DefaultLocation)

--- a/ClangPowerTools/ClangPowerTools/clang-build.ps1
+++ b/ClangPowerTools/ClangPowerTools/clang-build.ps1
@@ -862,11 +862,11 @@ Function Get-VisualStudio-Path()
     if (Test-Path $kVsWhereLocation)
     {
       [string] $product = If ([string]::IsNullOrEmpty($aVisualStudioSku)) { "*" } Else { "Microsoft.VisualStudio.Product.$aVisualStudioSku" } # Specific version set? Use that one. Else, pick the only available one
-      return (& "$kVsWhereLocation" -nologo `
-                                    -property installationPath `
-                                    -products $product `
-                                    -prerelease `
-                                    -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64)
+      return @(& "$kVsWhereLocation" -nologo `
+                                     -property installationPath `
+                                     -products $product `
+                                     -prerelease `
+                                     -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64)[0]
     }
 
     if (Test-Path -Path $kVs15DefaultLocation)

--- a/ClangPowerTools/ClangPowerTools/sample-clang-build.ps1
+++ b/ClangPowerTools/ClangPowerTools/sample-clang-build.ps1
@@ -84,6 +84,12 @@
                        - 'webkit'
                        - 'mozilla'
 
+.PARAMETER aVisualStudioSku
+      Alias 'vs-sku'. Sku of Visual Studio (VC++) installed and that'll be used for
+      standard library include directories. E.g. Professional.
+
+      This option is mandatory only if multiple Sku instances with the same version can be found
+
 .EXAMPLE
     PS .\sample-clang-build.ps1 -dir -proj foo,bar -file meow -tidy "-*,modernize-*"
     <Description of example>
@@ -124,6 +130,7 @@ param( [alias("proj")]        [Parameter(Mandatory=$false)][string[]] $aVcxprojT
      , [alias("tidy")]        [Parameter(Mandatory=$false)][string]   $aTidyFlags
      , [alias("tidy-fix")]    [Parameter(Mandatory=$false)][string]   $aTidyFixFlags
      , [alias("format-style")] [Parameter(Mandatory=$false)][string]  $aAfterTidyFixFormatStyle
+     , [alias("vs-sku")]       [Parameter(Mandatory=$false)][string]  $aVisualStudioSku
      )
 
 # ------------------------------------------------------------------------------------------------
@@ -139,7 +146,6 @@ Set-Variable -name kClangCompileFlags                                       -Opt
                                                     )
 
 Set-Variable -name kVisualStudioVersion -value "2017"                       -Option Constant
-Set-Variable -name kVisualStudioSku     -value "Professional"               -Option Constant
 
 # ------------------------------------------------------------------------------------------------
 
@@ -219,7 +225,12 @@ if ($aDisableNameRegexMatching)
 }
 
 $scriptParams += ("-aVisualStudioVersion", $kVisualStudioVersion)
-$scriptParams += ("-aVisualStudioSku",     $kVisualStudioSku)
+
+if (![string]::IsNullOrEmpty($aVisualStudioSku))
+{
+  $scriptParams += ("-aVisualStudioSku", $aVisualStudioSku)
+}
+
 $scriptParams += ("-aTidyHeaderFilter",    ".*")
 
 Invoke-Expression "&'$clangScript' $scriptParams"


### PR DESCRIPTION
In our team, some people use VS Professional edition, and some use VS Enterprise edition. And our CI server only has the BuildTools. So we do not want to explicitly state which SKU to use.

Fortunately, vswhere.exe accepts '*' for -products, which will pick any available SKU. As long as you have only one edition per version installed, this will work.

The original settings with explicitly providing the SKU still works for backward compatibility, and in case you have multiple SKU's installed (is that even possible?)