### PR TITLE
New option to override the Clang 'bin' directory

### DIFF
--- a/ClangPowerTools/ClangPowerTools/ClangPowerTools.csproj
+++ b/ClangPowerTools/ClangPowerTools/ClangPowerTools.csproj
@@ -75,6 +75,7 @@
     <Compile Include="AutomationUtil.cs" />
     <Compile Include="ClangCheckAttribute.cs" />
     <Compile Include="Commands\ClangFormatCommand.cs" />
+    <Compile Include="Convertors\ClangBinDirConvertor.cs" />
     <Compile Include="DialogOptionsModel\ClangTidyOptions.cs" />
     <Compile Include="Commands\BasicCommand.cs" />
     <Compile Include="Commands\StopClang.cs" />

--- a/ClangPowerTools/ClangPowerTools/Convertors/ClangBinDirConvertor.cs
+++ b/ClangPowerTools/ClangPowerTools/Convertors/ClangBinDirConvertor.cs
@@ -1,0 +1,214 @@
+﻿using System;
+using System.Collections;
+using System.ComponentModel;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+
+namespace ClangPowerTools.Convertors
+{
+  public enum ClangBinDetectionStatus
+  {
+    SystemPath,
+    ProgramFiles,
+    NotFound
+  }
+
+  public class ClangBinDirectory
+  {
+    public const string kAutodetectMarker = "Autodetected";
+    private const string kClangBinary = "clang++.exe";
+
+    private static readonly string[] kDefaultClangBinDirectories =
+    {
+      @"%ProgramW6432%\LLVM\bin",
+      @"%ProgramFiles(x86)%\LLVM\bin"
+    };
+
+    private bool mIsAutodetected;
+    private string mCustomPath;
+
+    public ClangBinDirectory()
+    {
+      this.IsAutodetected = true;
+    }
+
+    public ClangBinDirectory(string path)
+    {
+      this.CustomPath = path;
+    }
+
+    public bool IsAutodetected
+    {
+      get => this.mIsAutodetected;
+      set
+      {
+        this.mIsAutodetected = value;
+        this.mCustomPath = String.Empty;
+      }
+    }
+
+    public string CustomPath
+    {
+      get => this.mCustomPath;
+      set
+      {
+        this.mIsAutodetected = false;
+        this.mCustomPath = value;
+      }
+    }
+
+    public string Serialize()
+    {
+      return this.IsAutodetected ? ClangBinDirectory.kAutodetectMarker : this.CustomPath;
+    }
+
+    public static ClangBinDirectory Deserialize(string value)
+    {
+      var path = new ClangBinDirectory();
+
+      if (value != ClangBinDirectory.kAutodetectMarker)
+        path.CustomPath = value;
+
+      return path;
+    }
+
+    private static bool IsAccessibleFromSystemPath(string executable)
+    {
+      return Environment.
+        GetEnvironmentVariable("PATH").
+        Split(';').
+        FirstOrDefault(
+          pathDir => IsExecutableInDirectory(executable, pathDir)
+        ) != null;
+    }
+
+    private static bool IsExecutableInDirectory(string executable, string dir) => File.Exists(Path.Combine(dir, executable));
+
+    public static Tuple<ClangBinDetectionStatus, string> DetectClangBinDir()
+    {
+      if (IsAccessibleFromSystemPath(kClangBinary))
+      {
+        return Tuple.Create(ClangBinDetectionStatus.SystemPath, String.Empty);
+      }
+      else
+      {
+        var autodetectedInstallationDir = kDefaultClangBinDirectories.
+          Select(dir => Environment.ExpandEnvironmentVariables(dir)).
+          FirstOrDefault(dir => IsExecutableInDirectory(kClangBinary, dir));
+
+        if (autodetectedInstallationDir != default(string))
+        {
+          return Tuple.Create(ClangBinDetectionStatus.ProgramFiles, autodetectedInstallationDir);
+        }
+        else
+        {
+          return Tuple.Create(ClangBinDetectionStatus.NotFound, String.Empty);
+        }
+      }
+    }
+
+    public String Override
+    {
+      get
+      {
+        if (this.IsAutodetected)
+        {
+          var autodetectionStatus = DetectClangBinDir();
+          if (autodetectionStatus.Item1 == ClangBinDetectionStatus.ProgramFiles)
+            return autodetectionStatus.Item2;
+        }
+
+        if (!String.IsNullOrEmpty(this.CustomPath))
+          return this.CustomPath;
+
+        return null;
+      }
+    }
+  }
+
+  public class ClangBinDirConvertor : ComboBoxConvertor
+  {
+    public ClangBinDirConvertor() 
+    : base(new ArrayList {})
+    { }
+
+    public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+    {
+      if (sourceType == typeof(string))
+        return true;
+
+      return base.CanConvertFrom(context, sourceType);
+    }
+
+    public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+    {
+      string s = value as string;
+      if (s == null)
+        return base.ConvertFrom(context, culture, value);
+
+      var convertedPath = new ClangBinDirectory();
+
+      if (!s.StartsWith(ClangBinDirectory.kAutodetectMarker))
+        convertedPath.CustomPath = s;
+
+      return convertedPath;
+    }
+
+    public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
+    {
+      if (destinationType == typeof(string))
+      {
+        if (value == null)
+          return String.Empty;
+
+        if (value.GetType() == typeof(string))
+          return value;
+
+        if (value.GetType() == typeof(ClangBinDirectory))
+        {
+          var path = value as ClangBinDirectory;
+          return path.IsAutodetected ? GetAutodetectionLabel() : path.CustomPath;
+        }
+      }
+
+      return base.ConvertTo(context, culture, value, destinationType);
+    }
+
+    private String GetAutodetectionLabel()
+    {
+      var autodetectionLabel = ClangBinDirectory.kAutodetectMarker + " in ";
+
+      var autodetectionStatus = ClangBinDirectory.DetectClangBinDir();
+
+      switch (autodetectionStatus.Item1)
+      {
+        case ClangBinDetectionStatus.SystemPath:
+          autodetectionLabel += "system %PATH%";
+          break;
+
+        case ClangBinDetectionStatus.ProgramFiles:
+          autodetectionLabel += autodetectionStatus.Item2;
+          break;
+
+        case ClangBinDetectionStatus.NotFound:
+          autodetectionLabel += "(not found)";
+          break;
+
+        default:
+          throw new NotSupportedException();
+      }
+
+      return autodetectionLabel;
+    }
+
+    public override StandardValuesCollection GetStandardValues(ITypeDescriptorContext context)
+    {
+      return new StandardValuesCollection(
+        new ArrayList
+        {
+          new ClangBinDirectory()
+        } );
+    }
+  }
+}

--- a/ClangPowerTools/ClangPowerTools/DialogOptionsModel/ClangOptions.cs
+++ b/ClangPowerTools/ClangPowerTools/DialogOptionsModel/ClangOptions.cs
@@ -30,6 +30,8 @@ namespace ClangPowerTools
 
     public bool ClangCompileAfterVsCompile { get; set; }
 
+    public string ClangBinDirectory { get; set; }
+
     public string Version { get; set; }
 
     #endregion

--- a/ClangPowerTools/ClangPowerTools/DialogOptionsView/ClangGeneralOptionsView.cs
+++ b/ClangPowerTools/ClangPowerTools/DialogOptionsView/ClangGeneralOptionsView.cs
@@ -67,6 +67,12 @@ namespace ClangPowerTools
     [Description("Automatically run Clang compile on the current source file, after successful MSVC compilation.")]
     public bool ClangCompileAfterVsCompile { get; set; }
 
+    [Category("General")]
+    [DisplayName("Clang 'bin' directory")]
+    [Description("TODO")]
+    [TypeConverter(typeof(ClangBinDirConvertor))]
+    public ClangBinDirectory ClangBinDirectory { get; set; }
+
     [Browsable(false)]
     public string Version { get; set; }
 
@@ -86,6 +92,7 @@ namespace ClangPowerTools
         TreatWarningsAsErrors = this.TreatWarningsAsErrors,
         AdditionalIncludes = this.AdditionalIncludes,
         VerboseMode = this.VerboseMode,
+        ClangBinDirectory = this.ClangBinDirectory.Serialize(),
         ClangFlags = this.ClangFlags.ToList(),
         ClangCompileAfterVsCompile = this.ClangCompileAfterVsCompile,
         Version = this.Version
@@ -111,6 +118,8 @@ namespace ClangPowerTools
 
       this.VerboseMode = loadedConfig.VerboseMode;
       this.ClangFlags = loadedConfig.ClangFlags.ToArray();
+
+      this.ClangBinDirectory = ClangBinDirectory.Deserialize(loadedConfig.ClangBinDirectory);
 
       this.ClangCompileAfterVsCompile = loadedConfig.ClangCompileAfterVsCompile;
       this.Version = loadedConfig.Version;

--- a/ClangPowerTools/ClangPowerTools/DialogOptionsView/ClangGeneralOptionsView.cs
+++ b/ClangPowerTools/ClangPowerTools/DialogOptionsView/ClangGeneralOptionsView.cs
@@ -69,7 +69,7 @@ namespace ClangPowerTools
 
     [Category("General")]
     [DisplayName("Clang 'bin' directory")]
-    [Description("TODO")]
+    [Description("Overrides the Clang binaries detection mechanism. By default, these are searched for in the System %PATH% or in the default install locations: %ProgramW6432%\LLVM\bin and %ProgramFiles(x86)%\LLVM\bin.")]
     [TypeConverter(typeof(ClangBinDirConvertor))]
     public ClangBinDirectory ClangBinDirectory { get; set; }
 

--- a/ClangPowerTools/ClangPowerTools/Script/ClangCompileTidyScript.cs
+++ b/ClangPowerTools/ClangPowerTools/Script/ClangCompileTidyScript.cs
@@ -87,6 +87,10 @@ namespace ClangPowerTools.Script
       if (0 == string.Compare(aGeneralOptions.AdditionalIncludes, ComboBoxConstants.kSystemIncludeDirectories))
         parameters = $"{parameters} {ScriptConstants.kSystemIncludeDirectories}";
 
+      var clangBinOverride = aGeneralOptions.ClangBinDirectory.Override;
+      if (clangBinOverride != null)
+        parameters = $"{parameters} {ScriptConstants.kClangBinDirectory} ''{clangBinOverride}''";
+
       return $"{parameters}";
     }
 

--- a/ClangPowerTools/ClangPowerTools/Script/ScriptConstants.cs
+++ b/ClangPowerTools/ClangPowerTools/Script/ScriptConstants.cs
@@ -36,6 +36,7 @@ namespace ClangPowerTools
     public const string kTidy = "-tidy";
     public const string kTidyFix = "-tidy-fix";
 
+    public const string kClangBinDirectory = "-clang-bin-dir";
     public const string kClangFlags = "-clang-flags";
     public const string kIncludeDirectores = "-include-dirs";
     public const string kProjectsToIgnore = "-proj-ignore"; 

--- a/ClangPowerTools/ClangPowerTools/clang-build.ps1
+++ b/ClangPowerTools/ClangPowerTools/clang-build.ps1
@@ -101,7 +101,11 @@
 
 .PARAMETER aClangBinDirectory
       Alias 'clang-bin-dir'. Manual override of the Clang "bin" directory.
-	  TODO
+      When not provided, the script looks for the Clang binaries in the following locations:
+      - The directories from the system %PATH%
+      - %ProgramW6432%\LLVM\bin
+      - %ProgramFiles(x86)%\LLVM\bin
+      If the parameter is present, it should be a path to the 'bin' directory of a Clang install.
 
 .PARAMETER aVisualStudioVersion
       Alias 'vs-ver'. Version of Visual Studio (VC++) installed and that'll be used for
@@ -2230,7 +2234,6 @@ Function Process-Project( [Parameter(Mandatory=$true)][string]       $vcxprojPat
 # Script entry point
 
 Clear-Host # clears console
-$VerbosePreference = "Continue"
 
 #-------------------------------------------------------------------------------------------------
 # Print script parameters
@@ -2251,7 +2254,7 @@ if ($bParams)
 
 Write-Verbose "CPU logical core count: $kLogicalCoreCount"
 
-# If LLVM location is overridden, place it first in PATH
+# If the LLVM location is overridden, it will be the first in PATH
 if (![string]::IsNullOrEmpty($aClangBinDirectory))
 {
   Write-Verbose "LLVM location override: $aClangBinDirectory"


### PR DESCRIPTION
WIP for #199.

The Clang `bin` directory can now be overridden from the General options screen. Normally it is autodetected by looking for `clang++.exe` in the following locations, in this order:
* System `%PATH%`
* `%ProgramW6432%\LLVM\bin`
* `%ProgramFiles(x86)%\LLVM\bin`.

If the `bin` directory is overridden or the `.exe` is found in one of the two `Program Files` locations then the corresponding path is *prepended* to the System `%PATH%` before calling the Clang binaries.

The combo-box type converter is brittle. Unwanted small changes in the combo text may break the implemented mechanism.

2 known TODOs to fix + 1 `VerbosePreference` to remove.