### PR TITLE
use the whole file name of stdafx to detect stdafx dir

### DIFF
--- a/ClangPowerTools/ClangPowerTools/clang-build.ps1
+++ b/ClangPowerTools/ClangPowerTools/clang-build.ps1
@@ -1047,7 +1047,7 @@ Function Get-ProjectStdafxDir( [Parameter(Mandatory=$true)]  [string]   $pchHead
     # we need to use only backslashes so that we can match against file header paths
     $pchHeaderName = $pchHeaderName.Replace("/", "\")
 
-    $stdafxPath = $projectHeaders | Where-Object { $_.EndsWith($pchHeaderName) }
+    $stdafxPath = $projectHeaders | Where-Object { (Get-FileName -path $_) -eq $pchHeaderName }
   }
 
   if ([string]::IsNullOrEmpty($stdafxPath))


### PR DESCRIPTION
The current implementation assumes that only one file matches to EndWith($pchHeaderName)
I have a project with:
- stdafx.h - precompiled file
- stdafx.cpp - precompiled file
- commonstdafx.h - normal file