### PR TITLE
Fix random bug separating Clang output text into multiple lines (fixes #42)

### DIFF
--- a/ClangPowerTools/ClangPowerTools/clang-build.ps1
+++ b/ClangPowerTools/ClangPowerTools/clang-build.ps1
@@ -2017,9 +2017,10 @@ Function Run-ClangJobs([Parameter(Mandatory=$true)] $clangJobs)
 
     Push-Location $job.WorkingDirectory
 
-    $callOutput = & $job.FilePath $job.ArgumentList.Split(' ') 2>&1 |`
-                  ForEach-Object { $_.ToString() } |`
-                  Out-String
+    # When PowerShell encounters errors, the first one is handled differently from consecutive ones
+    # To circumvent this, do not execute the job directly, but execute it via cmd.exe
+    # See also https://stackoverflow.com/a/35980675 
+    $callOutput = cmd /c $job.FilePath $job.ArgumentList.Split(' ') '2>&1' | Out-String
 
     $callSuccess = $LASTEXITCODE -eq 0
 


### PR DESCRIPTION
The issue was that clang output such as

> blah.cpp:123:1: warning: some message
>
> 1 warning generated.

can result in an array something like

  [ "blah.cpp:"
  , "123:1: "
  , "warning: some message\r\n"
  , "\r\n\r\n"
  , "1 "
  , "warning generated.\r\n"
  ]
These array items must be concatenated _without_ adding a newline (but keeping the existing "\r\n")