### PR TITLE
Correctly handle empty project files.

### DIFF
--- a/ClangPowerTools/ClangPowerTools/clang-build.ps1
+++ b/ClangPowerTools/ClangPowerTools/clang-build.ps1
@@ -692,10 +692,15 @@ Function Should-IgnoreProject([Parameter(Mandatory=$true)][string] $vcxprojPath)
   return $false
 }
 
-Function Should-CompileFile([Parameter(Mandatory=$true)][System.Xml.XmlNode] $fileNode
+Function Should-CompileFile([Parameter(Mandatory=$false)][System.Xml.XmlNode] $fileNode
                            ,[Parameter(Mandatory=$false)][string] $pchCppName
                            )
 {
+  if ($fileNode -eq $null)
+  {
+    return $false
+  }
+
   [string] $file = $fileNode.Include
 
   if (($file -eq $null) -or (![string]::IsNullOrEmpty($pchCppName) -and ($file -eq $pchCppName)))


### PR DESCRIPTION
This is a fix for an exception being thrown from Get-ProjectFilesToCompile when attempting to run Clang Power Tools on an empty .vcxproj file.

When a project is empty the file nodes are null, which are being bound to the mandatory fileNode parameter of Should-CompileFile. This error was likely happening before the prior change to support the ExcludedFromBuild MSBuild property, as it was trying to dereference the Include field of each node.

In our particular case, some of our solutions have an empty project in them for certain continuous integration scripts to use on our build servers, so this fix addresses the problem.