### PR TITLE
basic support for compiling C files

### DIFF
--- a/ClangPowerTools/ClangPowerTools/psClang/msbuild-project-data.ps1
+++ b/ClangPowerTools/ClangPowerTools/psClang/msbuild-project-data.ps1
@@ -245,10 +245,10 @@ Function Get-Project-CppStandard()
     return $cppStdClangValue
 }
 
-Function Get-ClangCompileFlags()
+Function Get-ClangCompileFlags([Parameter(Mandatory = $false)][bool] $isCpp = $true)
 {
     [string[]] $flags = $aClangCompileFlags
-    if (!($flags -match "-std=.*"))
+    if ($isCpp -and !($flags -match "-std=.*"))
     {
         [string] $cppStandard = Get-Project-CppStandard
 
@@ -276,7 +276,7 @@ Function Get-ProjectPlatformToolset()
 
 Function Get-ProjectIncludeDirectories()
 {
-    [string[]] $returnArray = ($IncludePath -split ";")                                                         | `
+    [string[]] $returnArray = ($IncludePath -split ";")                                   | `
         Where-Object { ![string]::IsNullOrWhiteSpace($_) }                                | `
         ForEach-Object { Canonize-Path -base $ProjectDir -child $_.Trim() -ignoreErrors } | `
         Where-Object { ![string]::IsNullOrEmpty($_) }                                     | `


### PR DESCRIPTION
closes #321 

Very basic support. Files that end with `.c` will pass `-x c` instead of `-x c++` to the compiler and the `-std=YY` is not added.

For my use case it's very useful because we include zlib in the project and I just want to compile the C files.