### PR TITLE
Add ability to detect and process translation units that include particular headers

### DIFF
--- a/ClangPowerTools/ClangPowerTools/clang-build.ps1
+++ b/ClangPowerTools/ClangPowerTools/clang-build.ps1
@@ -798,7 +798,13 @@ Function Process-Project( [Parameter(Mandatory=$true)][string]       $vcxprojPat
   # FIND LIST OF CPPs TO PROCESS
 
   [System.Collections.Hashtable] $projCpps = @{}
-  Get-ProjectFilesToCompile -pchCppName  $stdafxCpp | ForEach-Object { $projCpps[$_] = $true }
+  foreach ($fileToCompile in (Get-ProjectFilesToCompile -pchCppName $stdafxCpp))
+  {
+    if (![string]::IsNullOrEmpty($fileToCompile))
+    {
+      $projCpps[$fileToCompile] = $true
+    }
+  }
 
   if ($projCpps.Count -gt 0 -and $aCppToCompile.Count -gt 0)
   {
@@ -953,25 +959,35 @@ Write-Verbose "Scanning for project files"
 [System.IO.FileInfo[]] $projects = Get-Projects
 Write-Verbose ("Found $($projects.Count) projects")
 
+# ------------------------------------------------------------------------------------------------
+# If we get headers in the -file arg we have to detect CPPs that include that header
+
+if ($aCppToCompile.Count -gt 0)
+{
+  # We've been given particular files to compile. If headers are among them
+  # we'll find all source files that include them and tag them for processing.
+  [string[]] $headerRefs = Get-HeaderReferences -files $aCppToCompile
+  if ($headerRefs.Count -gt 0)
+  {
+    Write-Verbose-Array -name "Detected source files" -array $headerRefs
+
+    $aCppToCompile += $headerRefs
+  }
+}
+# ------------------------------------------------------------------------------------------------
+
 [System.IO.FileInfo[]] $projectsToProcess = @()
 
-if ([string]::IsNullOrEmpty($aVcxprojToCompile) -and
-    [string]::IsNullOrEmpty($aVcxprojToIgnore))
+if (!$aVcxprojToCompile -and !$aVcxprojToIgnore)
 {
-  Write-Verbose "PROCESSING ALL PROJECTS"
-  $projectsToProcess = $projects
+  $projectsToProcess = $projects # we process all projects
 }
 else
 {
-  $projectsToProcess = $projects |
+  # some filtering has to be done
+  $projectsToProcess = $projects | `
                        Where-Object {       (Should-CompileProject -vcxprojPath $_.FullName) `
                                       -and !(Should-IgnoreProject  -vcxprojPath $_.FullName ) }
-
-  if ($projectsToProcess.Count -gt 1)
-  {
-    Write-Output ("PROJECTS: `n`t" + ($projectsToProcess -join "`n`t"))
-    $projectsToProcess = $projectsToProcess
-  }
 
   if ($projectsToProcess.Count -eq 0)
   {
@@ -979,16 +995,31 @@ else
   }
 }
 
-# ------------------------------------------------------------------------------------------------
-# If we get headers in the -file arg we have to detect CPPs that include that header
-
-if ($aCppToCompile.Count -gt 0)
+if ($aCppToCompile -and $projectsToProcess.Count -gt 1)
 {
-  [string[]] $headerRefs = Get-HeaderReferences -files $aCppToCompile
-  if ($headerRefs.Count -gt 0)
+  # We've been given particular files to compile, we can narrow down 
+  # the projects to be processed (those that include any of the particular files)
+  
+  # For obvious performance reasons, no filtering is done when there's only one project to process.
+  [System.IO.FileInfo[]] $projectsThatIncludeFiles = Get-SourceCodeIncludeProjects -projectPool $projectsToProcess `
+                                                                                   -files $aCppToCompile
+  Write-Verbose-Array -name "Detected projects" -array $projectsThatIncludeFiles
+ 
+  # some projects include files using wildcards, we won't match anything in them
+  # so when matching nothing we don't do filtering at all
+  if ($projectsThatIncludeFiles)
   {
-    $aCppToCompile += $headerRefs
+    $projectsToProcess = $projectsThatIncludeFiles
   }
+}
+
+if ($projectsToProcess.Count -eq $projects.Count)
+{
+  Write-Verbose "PROCESSING ALL PROJECTS"
+}
+else
+{
+  Write-Output ("PROJECTS: `n`t" + ($projectsToProcess -join "`n`t"))
 }
 
 # ------------------------------------------------------------------------------------------------

--- a/ClangPowerTools/ClangPowerTools/psClang/get-header-references.ps1
+++ b/ClangPowerTools/ClangPowerTools/psClang/get-header-references.ps1
@@ -1,26 +1,28 @@
-[System.IO.FileInfo[]] $global:filePool = @()
-
 # line limit for scanning files for #include
-[int] $global:cpt_header_include_line_limit = 100
+[int] $global:cpt_header_include_line_limit = 30
 
-[string[]] $global:cppExtensions = @()
+# after the line limit, if any includes are still found we
+# extend the limit with this value
+[int] $global:cpt_header_include_line_extension = 10
+
 [string[]] $global:headerExtensions = @('h', 'hh', 'hpp', 'hxx')
 [string[]] $global:sourceExtensions = @('c', 'cc', 'cpp', 'cxx')
 
-Function detail:FindHeaderReferences( [Parameter(Mandatory = $false)] [string[]] $files
-                                    , [Parameter(Mandatory = $false)][System.Collections.Hashtable] $alreadyFound = @{}
+Function detail:FindHeaderReferences( [Parameter(Mandatory = $false)] [string[]] $headers
+                                    , [Parameter(Mandatory = $false)] [System.IO.FileInfo[]] $filePool
+                                    , [Parameter(Mandatory = $false)] [System.Collections.Hashtable] $alreadyFound = @{}
                                     )
 {
-    if ($files.Count -eq 0)
+    if (!$headers)
     {
         return @()
     }
-    
-    [string] $regexHeaders = ($files | ForEach-Object { ([System.IO.FileInfo]$_).BaseName } `
-                                     | Select-Object -Unique `
-                                     | Where-Object { $_ -ine "stdafx" -and $_ -ine "resource" } `
+
+    [string] $regexHeaders = ($headers | ForEach-Object { ([System.IO.FileInfo]$_).BaseName } `
+                                       | Select-Object -Unique `
+                                       | Where-Object { $_ -ine "stdafx" -and $_ -ine "resource" } `
                              ) -join '|'
-                             
+
     if ($regexHeaders.Length -eq 0)
     {
         return @()
@@ -30,11 +32,12 @@ Function detail:FindHeaderReferences( [Parameter(Mandatory = $false)] [string[]]
     Write-Debug "Regex for header reference find: $regex`n"
 
     [string[]] $returnRefs = @()
-    if ($global:filePool.Count -eq 0)
+    if (!$filePool)
     {
+        # initialize pool of files that we look into
         [string[]] $allFileExts = ($global:sourceExtensions + `
                                    $global:headerExtensions) | ForEach-Object { "*.$_" }
-        $global:filePool = Get-ChildItem -recurse -include $allFileExts
+        $filePool = Get-ChildItem -recurse -include $allFileExts
     }
 
     foreach ($file in $filePool)
@@ -43,20 +46,34 @@ Function detail:FindHeaderReferences( [Parameter(Mandatory = $false)] [string[]]
         {
             continue
         }
-        
+
         [int] $lineCount = 0
+        [int] $lineLimit = $global:cpt_header_include_line_limit
         foreach($line in [System.IO.File]::ReadLines($file))
         {
-            $lineCount += 1
-            if ($lineCount -gt $global:cpt_header_include_line_limit)
+            if ([string]::IsNullOrWhiteSpace($line))
             {
-                break
+                # skip empty lines
+                continue
             }
 
-            if ($line -match $regex -and !$alreadyFound.ContainsKey($file.FullName))
+            if ($line -match $regex)
             {
-                $alreadyFound[$file.FullName] = $true
-                $returnRefs += $file.FullName
+                if ( ! $alreadyFound.ContainsKey($file.FullName))
+                {
+                    $alreadyFound[$file.FullName] = $true
+                    $returnRefs += $file.FullName
+                }
+
+                if ($lineCount -eq $lineLimit)
+                {
+                    # we still have includes to scan
+                    $lineLimit += $global:cpt_header_include_line_extension
+                }
+            }
+
+            if ( (++$lineCount) -gt $lineLimit)
+            {
                 break
             }
         }
@@ -71,7 +88,8 @@ Function detail:FindHeaderReferences( [Parameter(Mandatory = $false)] [string[]]
         {
             Write-Debug "[!] Recursive reference detection in progress for: "
             Write-Debug ($headersLeftToSearch -join "`n")
-            $returnRefs += detail:FindHeaderReferences -files        $headersLeftToSearch `
+            $returnRefs += detail:FindHeaderReferences -headers      $headersLeftToSearch `
+                                                       -filePool     $filePool `
                                                        -alreadyFound $alreadyFound
         }
     }
@@ -93,7 +111,6 @@ have to compiled. This function detects those files that include it.
 .PARAMETER files
 Header files of which we want references to be found
 Any files that are not headers will be ignored.
-.RETURNS 
 #>
 Function Get-HeaderReferences([Parameter(Mandatory = $false)][string[]] $files)
 {
@@ -102,16 +119,95 @@ Function Get-HeaderReferences([Parameter(Mandatory = $false)][string[]] $files)
         return @()
     }
 
-    # we use this as a cache for storing paths of all headers and files detected
-    # in the source directory, will get really large.
-    $global:filePool = @()
-
     # we take interest only in files that reference headers
     $files = $files | Where-Object { FileHasExtension -filePath $_ `
                                                       -ext $global:headerExtensions }
 
-    [string[]] $refs = detail:FindHeaderReferences -file $files
+    [string[]] $refs = @()
 
-    $global:filePool = @() # free memory
+    if ($files.Count -gt 0)
+    {
+        Write-Verbose-Timed "Headers changed. Detecting which source files to process..."
+        $refs = detail:FindHeaderReferences -headers $files
+        Write-Verbose-Timed "Finished detecting source files."
+    }
+
     return $refs
+}
+
+<#
+.SYNOPSIS
+Detects projects that reference given source files (i.e. cpps).
+
+Returns an array with full paths of detected projects.
+.DESCRIPTION
+When modifying a file, only projects that reference that file should be recompiled.
+.PARAMETER projectPool
+Projects in which to look
+.PARAMETER files
+Source files to be found in projects.
+#>
+Function Get-SourceCodeIncludeProjects([Parameter(Mandatory = $false)][System.IO.FileInfo[]] $projectPool,
+                                       [Parameter(Mandatory = $false)][string[]] $files)
+{
+    [System.Collections.Hashtable] $fileCache = @{}
+    foreach ($file in $files)
+    {
+        if ($file)
+        {
+            $fileCache[$file.Trim().ToLower()] = $true
+        }
+    }
+
+    [System.IO.FileInfo[]] $matchedProjects = @()
+
+    [string] $clPrefix    = '<ClCompile Include="'
+    [string] $clSuffix    = '" />'
+    [string] $endGroupTag = '</ItemGroup>'
+
+    foreach ($proj in $projectPool)
+    {
+        [string] $projDir  = $proj.Directory.FullName
+
+        [bool] $inClIncludeSection = $false
+        foreach($line in [System.IO.File]::ReadLines($proj.FullName))
+        {
+            $line = $line.Trim()
+
+            if ($line.StartsWith($clPrefix))
+            {
+                if (!$inClIncludeSection)
+                {
+                    $inClIncludeSection = $true
+                }
+
+                [string] $filePath = $line.Substring($clPrefix.Length, `
+                                                     $line.Length - $clPrefix.Length - $clSuffix.Length)
+                if (![System.IO.Path]::IsPathRooted($filePath))
+                {
+                    $filePath = Canonize-Path -base $projDir -child $filePath -ignoreErrors
+                }
+                if ([string]::IsNullOrEmpty($filePath))
+                {
+                    continue
+                }
+
+                [System.IO.FileInfo] $sourceFile = $filePath
+                if ($fileCache.ContainsKey($sourceFile.FullName.Trim().ToLower()) -or `
+                    $fileCache.ContainsKey($sourceFile.Name.Trim().ToLower()))
+                {
+                    $matchedProjects += $proj
+                    break
+                }
+            }
+
+            if ($inClIncludeSection -and $line -eq $endGroupTag)
+            {
+                # nothing more to check in this project
+                break
+            }
+        }
+    }
+
+    return $matchedProjects
 }

--- a/ClangPowerTools/ClangPowerTools/psClang/get-header-references.ps1
+++ b/ClangPowerTools/ClangPowerTools/psClang/get-header-references.ps1
@@ -1,0 +1,117 @@
+[System.IO.FileInfo[]] $global:filePool = @()
+
+# line limit for scanning files for #include
+[int] $global:cpt_header_include_line_limit = 100
+
+[string[]] $global:cppExtensions = @()
+[string[]] $global:headerExtensions = @('h', 'hh', 'hpp', 'hxx')
+[string[]] $global:sourceExtensions = @('c', 'cc', 'cpp', 'cxx')
+
+Function detail:FindHeaderReferences( [Parameter(Mandatory = $false)] [string[]] $files
+                                    , [Parameter(Mandatory = $false)][System.Collections.Hashtable] $alreadyFound = @{}
+                                    )
+{
+    if ($files.Count -eq 0)
+    {
+        return @()
+    }
+    
+    [string] $regexHeaders = ($files | ForEach-Object { ([System.IO.FileInfo]$_).BaseName } `
+                                     | Select-Object -Unique `
+                                     | Where-Object { $_ -ine "stdafx" -and $_ -ine "resource" } `
+                             ) -join '|'
+                             
+    if ($regexHeaders.Length -eq 0)
+    {
+        return @()
+    }
+
+    [string] $regex = "[/""]($regexHeaders)\.($($global:headerExtensions -join '|'))"""
+    Write-Debug "Regex for header reference find: $regex`n"
+
+    [string[]] $returnRefs = @()
+    if ($global:filePool.Count -eq 0)
+    {
+        [string[]] $allFileExts = ($global:sourceExtensions + `
+                                   $global:headerExtensions) | ForEach-Object { "*.$_" }
+        $global:filePool = Get-ChildItem -recurse -include $allFileExts
+    }
+
+    foreach ($file in $filePool)
+    {
+        if ($alreadyFound.ContainsKey($file.FullName))
+        {
+            continue
+        }
+        
+        [int] $lineCount = 0
+        foreach($line in [System.IO.File]::ReadLines($file))
+        {
+            $lineCount += 1
+            if ($lineCount -gt $global:cpt_header_include_line_limit)
+            {
+                break
+            }
+
+            if ($line -match $regex -and !$alreadyFound.ContainsKey($file.FullName))
+            {
+                $alreadyFound[$file.FullName] = $true
+                $returnRefs += $file.FullName
+                break
+            }
+        }
+    }
+
+    if ($returnRefs.Count -gt 0)
+    {
+        [string[]] $headersLeftToSearch = ($returnRefs | Where-Object `
+                                          { FileHasExtension -filePath $_ `
+                                                             -ext $global:headerExtensions } )
+        if ($headersLeftToSearch.Count -gt 0)
+        {
+            Write-Debug "[!] Recursive reference detection in progress for: "
+            Write-Debug ($headersLeftToSearch -join "`n")
+            $returnRefs += detail:FindHeaderReferences -files        $headersLeftToSearch `
+                                                       -alreadyFound $alreadyFound
+        }
+    }
+
+    $returnRefs = $returnRefs | Select-Object -Unique
+    Write-Debug "Found header refs (regex $regex)"
+    Write-Debug ($returnRefs -join "`n")
+    return $returnRefs
+}
+
+<#
+.SYNOPSIS
+Detects source files that reference given headers.
+
+Returns an array with full paths of files that reference the header(s).
+.DESCRIPTION
+When modifying a header, all translation units that include that header
+have to compiled. This function detects those files that include it.
+.PARAMETER files
+Header files of which we want references to be found
+Any files that are not headers will be ignored.
+.RETURNS 
+#>
+Function Get-HeaderReferences([Parameter(Mandatory = $false)][string[]] $files)
+{
+    if ($files.Count -eq 0)
+    {
+        return @()
+    }
+
+    # we use this as a cache for storing paths of all headers and files detected
+    # in the source directory, will get really large.
+    $global:filePool = @()
+
+    # we take interest only in files that reference headers
+    $files = $files | Where-Object { FileHasExtension -filePath $_ `
+                                                      -ext $global:headerExtensions }
+
+    [string[]] $refs = detail:FindHeaderReferences -file $files
+
+    $global:filePool = @() # free memory
+    return $refs
+}

--- a/ClangPowerTools/ClangPowerTools/psClang/io.ps1
+++ b/ClangPowerTools/ClangPowerTools/psClang/io.ps1
@@ -85,6 +85,20 @@ Function IsFileMatchingName( [Parameter(Mandatory = $true)][string] $filePath
     }
 }
 
+Function FileHasExtension( [Parameter(Mandatory = $true)][string]   $filePath
+                         , [Parameter(Mandatory = $true)][string[]] $ext
+                         )
+{
+    foreach ($e in $ext)
+    {
+        if ($filePath.EndsWith($e))
+        {
+            return $true
+        }
+    }
+    return $false
+}
+
 <#
   .DESCRIPTION
   Merges an absolute and a relative file path.

--- a/ClangPowerTools/ClangPowerTools/psClang/io.ps1
+++ b/ClangPowerTools/ClangPowerTools/psClang/io.ps1
@@ -26,6 +26,11 @@ Function Write-Verbose-Array($array, $name)
     $array | ForEach-Object { Write-Verbose "  $_" }
 }
 
+Function Write-Verbose-Timed([parameter(ValueFromPipeline, Mandatory = $true)][string] $msg)
+{
+    Write-Verbose "$([DateTime]::Now.ToString("[HH:mm:ss]")) $msg"
+}
+
 Function Print-InvocationArguments()
 {
     $bParams = $PSCmdlet.MyInvocation.BoundParameters

--- a/ClangPowerTools/ClangPowerTools/psClang/io.tests.ps1
+++ b/ClangPowerTools/ClangPowerTools/psClang/io.tests.ps1
@@ -53,6 +53,16 @@ Describe "File IO" {
     IsFileMatchingName -filePath $path -matchName ".*" | Should          -BeExactly $true
   }
 
+  It "FileHasExtension" {
+    FileHasExtension -filePath "c:\foo.bar" -ext 'bar' | Should -BeExactly $true
+    FileHasExtension -filePath "c:\foo.bar" -ext 'bar2' | Should -BeExactly $false
+    FileHasExtension -filePath "c:\foo.bar" -ext @('bar') | Should -BeExactly $true
+    FileHasExtension -filePath "c:\foo.bar" -ext @('bar2') | Should -BeExactly $false
+    FileHasExtension -filePath "c:\foo.bar" -ext @('bar', 'bar2') | Should -BeExactly $true
+    FileHasExtension -filePath "c:\foo.bar" -ext @('bar2', 'bar') | Should -BeExactly $true
+    FileHasExtension -filePath "c:\foo.bar" -ext @('bar2', 'bar2') | Should -BeExactly $false
+  }
+
   It "Canonize-Path" {
     $sysDrive = "$env:SystemDrive\"
     Canonize-Path -base $sysDrive -child "Windows" | Should -Be $env:SystemRoot

--- a/ClangPowerTools/ClangPowerTools/sample-clang-build.ps1
+++ b/ClangPowerTools/ClangPowerTools/sample-clang-build.ps1
@@ -40,6 +40,8 @@
     If the -literal switch is present, name is matched exactly. Otherwise, regex matching is used,
     e.g. "table" ignores all CPPs containing 'table'.
 
+    Note: If any headers are given then all translation units that include them will be processed.
+
     Can be passed as comma separated values.
 
 .PARAMETER aUseParallelCompile


### PR DESCRIPTION
When a header is modified we have to compile all CPPs that include it, _or_ recompile the entire project.
This pull request detects those CPPs and processes them accordingly.