### PR TITLE
 Add support for running Clang-Tidy on VS13 (v120), VS15 (v140) and VS17 (v141) toolsets

### DIFF
--- a/ClangPowerTools/ClangPowerTools/clang-build.ps1
+++ b/ClangPowerTools/ClangPowerTools/clang-build.ps1
@@ -781,7 +781,17 @@ Function Process-Project( [Parameter(Mandatory=$true)][string]       $vcxprojPat
   [string] $platformToolset = Get-ProjectPlatformToolset
   Write-Verbose "Platform toolset: $platformToolset"
 
-  if ( ([int]$platformToolset.Remove(0, 1).Replace("_xp", "")) -le 140)
+  if ( ([int]$platformToolset.Remove(0, 1).Replace("_xp", "")) -le 120)
+  {
+    if ($global:cptVisualStudioVersion -ne '2013')
+    {
+      # we need to reload everything and use VS2013
+      Write-Verbose "Switching to VS2013 because of v120 toolset. Reloading project..."
+      $global:cptVisualStudioVersion = "2013"
+      LoadProject($vcxprojPath)
+    }
+  }
+  elseif ( ([int]$platformToolset.Remove(0, 1).Replace("_xp", "")) -le 140)
   {
     if ($global:cptVisualStudioVersion -ne '2015')
     {

--- a/ClangPowerTools/ClangPowerTools/psClang/msbuild-project-data.ps1
+++ b/ClangPowerTools/ClangPowerTools/psClang/msbuild-project-data.ps1
@@ -340,7 +340,7 @@ Function Get-ProjectIncludeDirectories()
 
     [string] $platformToolset = Get-ProjectPlatformToolset
 
-    if ($global:cptVisualStudioVersion -eq "2015")
+    if ($global:cptVisualStudioVersion -ne "2017")
     {
         $returnArray += Get-VisualStudio-Includes -vsPath $vsPath
     }

--- a/ClangPowerTools/ClangPowerTools/psClang/msbuild-project-load.ps1
+++ b/ClangPowerTools/ClangPowerTools/psClang/msbuild-project-load.ps1
@@ -225,6 +225,10 @@ Function InitializeMsBuildProjectProperties()
     }
 
     [string] $vsVer = "15.0"
+    if ($global:cptVisualStudioVersion -eq "2013")
+    {
+        $vsVer = "12.0"
+    }
     if ($global:cptVisualStudioVersion -eq "2015")
     {
         $vsVer = "14.0"

--- a/docs/QaA.md
+++ b/docs/QaA.md
@@ -113,5 +113,13 @@ Eg.
         value:           'some value'  
     ...
  
+### 👉 I found a bug, How can I debug the Clang Power Tools extension ?
+
+Clone the Clang Power Tools repository, open the Solution file and build the project. 
+Right click the project and do Properties -> Debug ->
+
+1. Select Start external program, enter "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\IDE\devenv.exe"
+2. In Command Line Arguments, add "/rootsuffix Exp"
+3. Start an instance (F5) and you will be able to set breakpoints etc.
 
  


### PR DESCRIPTION
# Support vs13 Toolset et al
Clang-Build.ps1 will now be able to run Clang-Tidy using the specified project toolset. 
Fixes #450 

This is tested using VisualStudio 2017 with the following changed Clang Power Tool settings:
```Compile flags: -std=c++11;-Wall;-Wmicrosoft;-Wno-invalid-token-paste;-Wno-unknown-pragmas;-Wno-unused-value```

**vs120:**
```
VERBOSE: Platform toolset: v120
VERBOSE: Switching to VS2013 because of v120 toolset. Reloading project...
...
VERBOSE: INVOKE: "\clang-tidy.exe" 
"C:\Users\hugo\source\repos\ConsoleApplication1\ConsoleApplication1\ConsoleApplication1.cpp" 
-checks=-*,google-* -header-filter=".*" -quiet -- 
-isystem"C:\Users\hugo\source\repos\ConsoleApplication1\ConsoleApplication1" -isystem"C:\Program Files (x86)\Microsoft 
Visual Studio 12.0\VC\include" -isystem"C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\atlmfc\include" 
-isystem"C:\Program Files (x86)\Windows Kits\10\Include\10.0.17134.0\ucrt" -isystem"C:\Program Files (x86)\Windows 
Kits\10\Include\10.0.17134.0\um" -isystem"C:\Program Files (x86)\Windows Kits\10\Include\10.0.17134.0\shared" 
-isystem"C:\Program Files (x86)\Windows Kits\10\Include\10.0.17134.0\winrt" -isystem"C:\Program Files (x86)\Windows 
Kits\10\Include\10.0.17134.0\cppwinrt" -std=c++11 -Wall -Wmicrosoft -Wno-invalid-token-paste -Wno-unknown-pragmas 
-Wno-unused-value -m32 "-DWIN32" "-D_DEBUG" "-D_CONSOLE" -DUNICODE -D_UNICODE -x c++
```

**vs140:**
```
VERBOSE: Platform toolset: v140
VERBOSE: Switching to VS2015 because of v140 toolset. Reloading project...
...
VERBOSE: INVOKE: "\clang-tidy.exe" 
"C:\Users\hugo\source\repos\ConsoleApplication1\ConsoleApplication1\ConsoleApplication1.cpp" 
-checks=-*,google-* -header-filter=".*" -quiet -- 
-isystem"C:\Users\hugo\source\repos\ConsoleApplication1\ConsoleApplication1" -isystem"C:\Program Files (x86)\Microsoft 
Visual Studio 14.0\VC\include" -isystem"C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\atlmfc\include" 
-isystem"C:\Program Files (x86)\Windows Kits\10\Include\10.0.17134.0\ucrt" -isystem"C:\Program Files (x86)\Windows 
Kits\10\Include\10.0.17134.0\um" -isystem"C:\Program Files (x86)\Windows Kits\10\Include\10.0.17134.0\shared" 
-isystem"C:\Program Files (x86)\Windows Kits\10\Include\10.0.17134.0\winrt" -isystem"C:\Program Files (x86)\Windows 
Kits\10\Include\10.0.17134.0\cppwinrt" -std=c++11 -Wall -Wmicrosoft -Wno-invalid-token-paste -Wno-unknown-pragmas 
-Wno-unused-value -m32 "-DWIN32" "-D_DEBUG" "-D_CONSOLE" -DUNICODE -D_UNICODE -x c++
```

**vs141:**
```
VERBOSE: Platform toolset: v141
...
VERBOSE: INVOKE: "\clang-tidy.exe" 
"C:\Users\hugo\source\repos\ConsoleApplication1\ConsoleApplication1\ConsoleApplication1.cpp" 
-checks=-*,google-* -header-filter=".*" -quiet -- 
-isystem"C:\Users\hugo\source\repos\ConsoleApplication1\ConsoleApplication1" -isystem"C:\Program Files (x86)\Microsoft 
Visual Studio\2017\Community\VC\Tools\MSVC\14.15.26726\include" -isystem"C:\Program Files (x86)\Microsoft Visual 
Studio\2017\Community\VC\Tools\MSVC\14.15.26726\atlmfc\include" -isystem"C:\Program Files (x86)\Windows 
Kits\10\Include\10.0.17134.0\ucrt" -isystem"C:\Program Files (x86)\Windows Kits\10\Include\10.0.17134.0\um" 
-isystem"C:\Program Files (x86)\Windows Kits\10\Include\10.0.17134.0\shared" -isystem"C:\Program Files (x86)\Windows 
Kits\10\Include\10.0.17134.0\winrt" -isystem"C:\Program Files (x86)\Windows Kits\10\Include\10.0.17134.0\cppwinrt" 
-std=c++11 -Wall -Wmicrosoft -Wno-invalid-token-paste -Wno-unknown-pragmas -Wno-unused-value -m32 "-DWIN32" "-D_DEBUG" 
"-D_CONSOLE" -DUNICODE -D_UNICODE -D_DEBUG_FUNCTIONAL_MACHINERY -x c++
```

# Updated QaA.md

Add some information on how to debug a vsix extension so that more people can get up to speed and try to solve bugs/issues/features.

This is my first time debugging a vsix extension, so please forgive me if I'm totaly off the mark here. 