### PR TITLE
Fix for file excluded from build in only 1 configuration

### DIFF
--- a/ClangPowerTools/ClangPowerTools/psClang/msbuild-project-data.ps1
+++ b/ClangPowerTools/ClangPowerTools/psClang/msbuild-project-data.ps1
@@ -140,9 +140,26 @@ Function Should-CompileFile([Parameter(Mandatory = $false)][System.Xml.XmlNode] 
         return $false
     }
 
-    [System.Xml.XmlNode] $excluded = $fileNode.SelectSingleNode("ns:ExcludedFromBuild", $global:xpathNS)
+    [string] $innerText = "false"
+    foreach ($child in $fileNode.ChildNodes)
+    {
+        if ($child.Name -ieq "ExcludedFromBuild")
+        {
+            if ($child.HasAttribute("Condition"))
+            {
+                [bool] $isApplicable = Evaluate-MSBuildCondition -condition $child.GetAttribute("Condition")
+                if (!$isApplicable)
+                {
+                    continue
+                }
+            }
+	    Write-Verbose "IT $($child.InnerText)"
+            $innerText = $child.InnerText
+            break
+        }
+    }
 
-    if (($excluded -ne $null) -and ($excluded.InnerText -ne $null) -and ($excluded.InnerText -ieq "true"))
+    if ($innerText -ieq "true")
     {
         return $false
     }


### PR DESCRIPTION
If one of the files is excluded from build in one of the configurations, but is active in other, current version of CPT takes random value of exclude then attempting to build that project.

Project example included
[TestExcl.zip](https://github.com/Caphyon/clang-power-tools/files/2729929/TestExcl.zip)
