### PR TITLE
Enable loading of default user property sheets

### DIFF
--- a/ClangPowerTools/ClangPowerTools/psClang/msbuild-project-load.ps1
+++ b/ClangPowerTools/ClangPowerTools/psClang/msbuild-project-load.ps1
@@ -274,6 +274,7 @@ Function InitializeMsBuildProjectProperties()
     Set-Var -name "ProjectName"              -value $MSBuildProjectName
     Set-Var -name "TargetName"               -value $MSBuildProjectName
 
+    Set-Var -name "UserRootDir"              -value "$LocalAppData\Microsoft\MSBuild\v4.0"
     # These would enable full project platform references parsing, experimental right now
     if ($env:CPT_LOAD_ALL -eq '1')
     {
@@ -282,7 +283,6 @@ Function InitializeMsBuildProjectProperties()
         Set-Var -name "VsInstallRoot"            -value (Get-VisualStudio-Path)
         Set-Var -name "MSBuildExtensionsPath"    -value "$(Get-VisualStudio-Path)\MSBuild"
         Set-Var -name "LocalAppData"             -value $env:LOCALAPPDATA
-        Set-Var -name "UserRootDir"              -value "$LocalAppData\Microsoft\MSBuild\v4.0"
         Set-Var -name "UniversalCRT_IncludePath" -value "${Env:ProgramFiles(x86)}\Windows Kits\10\Include\10.0.10240.0\ucrt"
     }
 


### PR DESCRIPTION
They are located in %USERROOTDIR% so we need to make sure this variable gets expanded even when `CPT_LOAD_ALL` is not set to `1`.