### PR TITLE
Link to msbuild::utilities::core assembly so that we can evaluate exp…

### DIFF
--- a/ClangPowerTools/ClangPowerTools/psClang/msbuild-expression-eval.ps1
+++ b/ClangPowerTools/ClangPowerTools/psClang/msbuild-expression-eval.ps1
@@ -1,5 +1,7 @@
 # REQUIRES io.ps1 to be included
 
+[System.Reflection.Assembly]::LoadWithPartialName("Microsoft.Build.Utilities.Core")
+
 Set-Variable -name "kMsbuildExpressionToPsRules" <#-option Constant#>     `
     -value @(                                                             `
         <# backticks are control characters in PS, replace them #>        `


### PR DESCRIPTION
…ressions such as $([Microsoft.Build.Utilities.ToolLocationHelper]::GetLatestSDKTargetPlatformVersion('Windows', '10.0'))