### PR TITLE
Rework project data retrieval to not rely on XPath selectors

### DIFF
--- a/ClangPowerTools/ClangPowerTools/clang-build.ps1
+++ b/ClangPowerTools/ClangPowerTools/clang-build.ps1
@@ -1037,7 +1037,7 @@ Function Process-Project( [Parameter(Mandatory=$true)][string]       $vcxprojPat
 #-------------------------------------------------------------------------------------------------
 # Script entry point
 
-Clear-Host # clears console
+#Clear-Host # clears console
 
 #-------------------------------------------------------------------------------------------------
 # If we didn't get a location to run CPT at, use the current working directory

--- a/ClangPowerTools/ClangPowerTools/clang-build.ps1
+++ b/ClangPowerTools/ClangPowerTools/clang-build.ps1
@@ -1037,7 +1037,7 @@ Function Process-Project( [Parameter(Mandatory=$true)][string]       $vcxprojPat
 #-------------------------------------------------------------------------------------------------
 # Script entry point
 
-#Clear-Host # clears console
+Clear-Host # clears console
 
 #-------------------------------------------------------------------------------------------------
 # If we didn't get a location to run CPT at, use the current working directory

--- a/ClangPowerTools/ClangPowerTools/psClang/itemdefinition-context.ps1
+++ b/ClangPowerTools/ClangPowerTools/psClang/itemdefinition-context.ps1
@@ -38,7 +38,7 @@ function Pop-ProjectItemContext()
     Write-Verbose "[CONTEXT] item namespace = @($global:itemPropertyNamespace)"
 }
 
-function Set-ProjectItemContext([Parameter(Mandatory = $true)][string] $name)
+function Set-ProjectItemContext([Parameter(Mandatory = $true)][AllowEmptyString()][string] $name)
 {
     if ( (VariableExists 'itemPropertyNameSpace') -and ($global:itemPropertyNamespace -eq $name) )
     {

--- a/ClangPowerTools/ClangPowerTools/psClang/msbuild-project-data.ps1
+++ b/ClangPowerTools/ClangPowerTools/psClang/msbuild-project-data.ps1
@@ -117,6 +117,11 @@ Function Get-ProjectFilesToCompile([Parameter(Mandatory = $false)][string] $pchC
             }
         }
 
+        if ($usePch -ieq 'Create')
+        {
+            continue # no point in compiling the PCH CPP
+        }
+
         if ($itemProps -ne $null -and $itemProps.ContainsKey('ExcludedFromBuild'))
         {
             if ($itemProps['ExcludedFromBuild'] -ieq 'true')

--- a/ClangPowerTools/ClangPowerTools/psClang/msbuild-project-data.ps1
+++ b/ClangPowerTools/ClangPowerTools/psClang/msbuild-project-data.ps1
@@ -137,7 +137,7 @@ Function Should-IgnoreFile([Parameter(Mandatory = $true)][string] $file)
 
 Function Get-ProjectFilesToCompile([Parameter(Mandatory = $false)][string] $pchCppName)
 {
-    [System.Xml.XmlElement[]] $projectEntries = @(Select-ProjectNodes($kVcxprojXpathCompileFiles) | `
+ <#   [System.Xml.XmlElement[]] $projectEntries = @(Select-ProjectNodes($kVcxprojXpathCompileFiles) | `
                                                   Where-Object { Should-CompileFile -fileNode $_ -pchCppName $pchCppName })
 
     [System.Collections.ArrayList] $files = @()
@@ -165,7 +165,9 @@ Function Get-ProjectFilesToCompile([Parameter(Mandatory = $false)][string] $pchC
                                                        "Pch" = $usePch; }
             }
         }
-    }
+    } #>
+
+    $files = Get-Project-Item "ClCompile"
 
     if ($files.Count -gt 0)
     {
@@ -213,7 +215,7 @@ Function Get-Project-SDKVer()
 }
 
 Function Is-Project-MultiThreaded()
-{    
+{
     Set-ProjectItemContext "ClCompile"
     $runtimeLibrary = Get-ProjectItemProperty "RuntimeLibrary"
     return ![string]::IsNullOrEmpty($runtimeLibrary)
@@ -416,7 +418,7 @@ Function Get-ProjectPreprocessorDefines()
     {
         return @()
     }
-    
+
     [string[]] $tokens = @($preprocDefNodes -split ";")
 
     # make sure we add the required prefix and escape double quotes

--- a/ClangPowerTools/ClangPowerTools/psClang/msbuild-project-load.ps1
+++ b/ClangPowerTools/ClangPowerTools/psClang/msbuild-project-load.ps1
@@ -17,9 +17,6 @@ if (! (Test-Path variable:global:ScriptParameterBackupValues))
   [System.Collections.Hashtable] $global:ScriptParameterBackupValues = @{}
 }
 
-# current vcxproj and property sheets
-[xml[]]  $global:projectFiles                    = @();
-
 # path of current project
 [string] $global:vcxprojPath                     = "";
 
@@ -629,7 +626,6 @@ function SanitizeProjectFile([string] $projectFilePath)
     Write-Verbose "`nSanitizing $projectFilePath"
 
     [xml] $fileXml = Get-Content $projectFilePath
-    $global:projectFiles += @($fileXml)
     $global:xpathNS = New-Object System.Xml.XmlNamespaceManager($fileXml.NameTable)
     $global:xpathNS.AddNamespace("ns", $fileXml.DocumentElement.NamespaceURI)
     $global:currentMSBuildFile = $projectFilePath
@@ -677,8 +673,6 @@ function LoadProject([string] $vcxprojPath)
     $global:vcxprojPath = $vcxprojPath
 
     InitializeMsBuildProjectProperties
-
-    $global:projectFiles = @()
 
     SanitizeProjectFile -projectFilePath $global:vcxprojPath
 }


### PR DESCRIPTION
This allows far easier retrieval of various project settings, using item properties, especially those set on a per-file basis.