### PR TITLE
Check for unset variables

### DIFF
--- a/ClangPowerTools/ClangPowerTools/psClang/msbuild-project-data.ps1
+++ b/ClangPowerTools/ClangPowerTools/psClang/msbuild-project-data.ps1
@@ -152,7 +152,7 @@ Function Get-ProjectHeaders()
 
 Function Get-Project-SDKVer()
 {
-    [string] $sdkVer = $WindowsTargetPlatformVersion
+    [string] $sdkVer = Get-Variable -Name 'WindowsTargetPlatformVersion' -ErrorAction 'Ignore'
 
     If ([string]::IsNullOrEmpty($sdkVer)) { "" } Else { $sdkVer.Trim() }
 }

--- a/ClangPowerTools/ClangPowerTools/psClang/msbuild-project-data.ps1
+++ b/ClangPowerTools/ClangPowerTools/psClang/msbuild-project-data.ps1
@@ -179,7 +179,11 @@ Function Get-Project-MultiThreaded-Define()
 
 Function Is-Project-Unicode()
 {
-    return $CharacterSet -ieq "Unicode"
+    if (Get-Variable 'CharacterSet' -ErrorAction 'Ignore')
+    {
+        return $CharacterSet -ieq "Unicode"
+    }
+    return $false
 }
 
 Function Get-Project-CppStandard()


### PR DESCRIPTION
Both the variables `$WindowsTargetPlatformVersion` and `$CharacterSet` are were read without checking for their existence. This resulted in the following following error message being printed: `"The variable '$...' cannot be retrieved because it has not been set."`.

I don't know if it's the best solution to the problem, but it got rid of the errors in my situation.

