### PR TITLE
Custom clang-tidy not working because of absolute path containing spaces

### DIFF
--- a/ClangPowerTools/ClangPowerTools/clang-build.ps1
+++ b/ClangPowerTools/ClangPowerTools/clang-build.ps1
@@ -762,7 +762,8 @@ Function Run-ClangJobs( [Parameter(Mandatory=$true)] $clangJobs
     # When PowerShell encounters errors, the first one is handled differently from consecutive ones
     # To circumvent this, do not execute the job directly, but execute it via cmd.exe
     # See also https://stackoverflow.com/a/35980675
-    $callOutput = cmd /c $job.FilePath $job.ArgumentList.Split(' ') '2>&1' | Out-String
+    
+    $callOutput = cmd /c "$($job.FilePath) $($job.ArgumentList) 2>&1" | Out-String
 
     $callSuccess = $LASTEXITCODE -eq 0
 

--- a/ClangPowerTools/ClangPowerTools/clang-build.ps1
+++ b/ClangPowerTools/ClangPowerTools/clang-build.ps1
@@ -407,17 +407,17 @@ Function Get-ClangIncludeDirectories( [Parameter(Mandatory=$false)][string[]] $i
 
   foreach ($includeDir in $includeDirectories)
   {
-    $returnDirs += "-isystem""$includeDir"""
+    $returnDirs += ("-isystem" + (Get-QuotedPath $includeDir))
   }
   foreach ($includeDir in $additionalIncludeDirectories)
   {
     if ($aTreatAdditionalIncludesAsSystemIncludes)
     {
-      $returnDirs += "-isystem""$includeDir"""
+      $returnDirs += ("-isystem" + (Get-QuotedPath $includeDir))
     }
     else
     {
-      $returnDirs += "-I""$includeDir"""
+      $returnDirs += ("-I"+ (Get-QuotedPath $includeDir))
     }
   }
 
@@ -465,10 +465,10 @@ Function Generate-Pch( [Parameter(Mandatory=$true)] [string]   $stdafxDir
 
   [string] $languageFlag = (Get-ProjectFileLanguageFlag -fileFullName $stdafxCpp)
 
-  [string[]] $compilationFlags = @("""$stdafx"""
+  [string[]] $compilationFlags = @((Get-QuotedPath $stdafx)
                                   ,$kClangFlagEmitPch
                                   ,$kClangFlagMinusO
-                                  ,"""$stdafxPch"""
+                                  ,(Get-QuotedPath $stdafxPch)
                                   ,$languageFlag
                                   ,(Get-ClangCompileFlags -isCpp ($languageFlag -ieq $kClangFlagFileIsCPP))
                                   ,$kClangFlagNoUnusedArg
@@ -529,13 +529,13 @@ Function Get-CompileCallArguments( [Parameter(Mandatory=$false)][string[]] $prep
   [string[]] $projectCompileArgs = @()
   if (! [string]::IsNullOrEmpty($pchFilePath) -and ! $fileToCompile.EndsWith($kExtensionC))
   {
-    $projectCompileArgs += @($kClangFlagIncludePch , """$pchFilePath""")
+    $projectCompileArgs += @($kClangFlagIncludePch , (Get-QuotedPath $pchFilePath))
   }
 
   [string] $languageFlag = (Get-ProjectFileLanguageFlag -fileFullName $fileToCompile)
 
   $projectCompileArgs += @( $languageFlag
-                          , """$fileToCompile"""
+                          , (Get-QuotedPath $fileToCompile)
                           , @(Get-ClangCompileFlags -isCpp ($languageFlag -ieq $kClangFlagFileIsCPP))
                           , $kClangFlagSupressLINK
                           , $preprocessorDefinitions
@@ -565,7 +565,7 @@ Function Get-TidyCallArguments( [Parameter(Mandatory=$false)][string[]] $preproc
                               , [Parameter(Mandatory=$false)][string]  $pchFilePath
                               , [Parameter(Mandatory=$false)][switch]  $fix)
 {
-  [string[]] $tidyArgs = @("""$fileToTidy""")
+  [string[]] $tidyArgs = @((Get-QuotedPath $fileToTidy))
   if ($fix -and $aTidyFixFlags -ne $kClangTidyUseFile)
   {
     $tidyArgs += "$kClangTidyFlagChecks$aTidyFixFlags"
@@ -615,7 +615,7 @@ Function Get-TidyCallArguments( [Parameter(Mandatory=$false)][string[]] $preproc
 
   if (! [string]::IsNullOrEmpty($pchFilePath) -and ! $fileToTidy.EndsWith($kExtensionC))
   {
-    $tidyArgs += @($kClangFlagIncludePch , """$pchFilePath""")
+    $tidyArgs += @($kClangFlagIncludePch , (Get-QuotedPath $pchFilePath))
   }
 
   if ($forceIncludeFiles)

--- a/ClangPowerTools/ClangPowerTools/psClang/io.ps1
+++ b/ClangPowerTools/ClangPowerTools/psClang/io.ps1
@@ -117,7 +117,7 @@ function HasProperty($object, $property)
 
 # File IO
 # ------------------------------------------------------------------------------------------------
-Function Get-QuotedPath([Parameter(Mandatory = $true)][string] $path)
+Function Get-QuotedPath([Parameter(Mandatory = $false)][string] $path)
 {
     if ([string]::IsNullOrWhiteSpace($path))
     {

--- a/ClangPowerTools/ClangPowerTools/psClang/io.ps1
+++ b/ClangPowerTools/ClangPowerTools/psClang/io.ps1
@@ -117,6 +117,23 @@ function HasProperty($object, $property)
 
 # File IO
 # ------------------------------------------------------------------------------------------------
+Function Get-QuotedPath([Parameter(Mandatory = $true)][string] $path)
+{
+    if ([string]::IsNullOrWhiteSpace($path))
+    {
+        return $path
+    }
+
+    [string] $returnPath = $path
+
+    if (!$path.StartsWith('"'))
+    {
+        $returnPath = """$path"""
+    }
+
+    return $returnPath
+}
+
 Function Remove-PathTrailingSlash([Parameter(Mandatory = $true)][string] $path)
 {
     return $path -replace '\\$', ''

--- a/ClangPowerTools/ClangPowerTools/psClang/io.tests.ps1
+++ b/ClangPowerTools/ClangPowerTools/psClang/io.tests.ps1
@@ -36,6 +36,17 @@ Describe "HasProperty" {
 }
 
 Describe "File IO" {
+
+  It "Get-QuotedPath" {
+   Get-QuotedPath ''       | Should -BeExactly ''
+   Get-QuotedPath '    '   | Should -BeExactly '    '
+   Get-QuotedPath '   '    | Should -BeExactly '   '
+   Get-QuotedPath 'test'   | Should -BeExactly '"test"'
+   Get-QuotedPath '"test"' | Should -BeExactly '"test"'
+   Get-QuotedPath 'c:\some file'   | Should -BeExactly '"c:\some file"'
+   Get-QuotedPath '"c:\some file"' | Should -BeExactly '"c:\some file"'
+  }
+
   It "Remove-PathTrailingSlash" {
     Remove-PathTrailingSlash "c:\windows\" | Should -BeExactly "c:\windows"
     Remove-PathTrailingSlash "c:\windows" | Should -BeExactly "c:\windows"


### PR DESCRIPTION
Change way workers invoke cmd because of occasional troubles when absolute exe paths are given