### PR TITLE
Add support for exporting JSON Compilation Databases

### DIFF
--- a/ClangPowerTools/ClangPowerTools/psClang/jsondb-export.ps1
+++ b/ClangPowerTools/ClangPowerTools/psClang/jsondb-export.ps1
@@ -1,0 +1,42 @@
+function JsonDB-Init()
+{
+  Set-Variable -name "kJsonCompilationDbPath" -value ("$(Get-Location)\compile_commands.json") -option Constant -scope Global
+  Set-Variable -name "kJsonCompilationDbCount" -value 0 -scope Global
+  
+  "[" | Out-File $kJsonCompilationDbPath -Encoding "UTF8"
+}
+
+function JsonDB-Append($text)
+{
+  $text | Out-File $kJsonCompilationDbPath -append -Encoding "UTF8"
+}
+
+function JsonDB-Finalize()
+{
+  JsonDB-Append "]"
+  Write-Output "Exported JSON Compilation Database to $kJsonCompilationDbPath"
+}
+
+function JsonDB-Push($directory, $file, $command)
+{
+  if ($kJsonCompilationDbCount -ge 1)
+  {
+    JsonDB-Append "  ,"
+  }
+  
+  # use only slashes
+  $command = $command.Replace('\', '/')
+  $file = $file.Replace('\', '/')
+  $directory = $directory.Replace('\', '/')
+  
+  # escape double quotes
+  $command = $command.Replace('"', '\"')
+  
+  # make paths relative to directory
+  $command = $command.Replace("$directory/", "")
+  $file = $file.Replace("$directory/", "")
+  
+  JsonDB-Append "  {`n    ""directory"": ""$directory"",`n    ""command"": ""$command"",`n    ""file"": ""$file""`n  }"
+   
+  Set-Variable -name "kJsonCompilationDbCount" -value ($kJsonCompilationDbCount + 1) -scope Global
+}


### PR DESCRIPTION
Making Clang Power Tools CLI able to export JSON Compilation Database files


**Notable info:**
- Use CPT as before, just add `-export-jsondb` switch
- When the switch is present, solutions/projects/files are processed as usual, but the compilation itself is skipped
- The exported `compile_commands.json` file will be located in the current working directory
- Exported file will be in UTF8, as required by clang tooling
- _Command_ and _File_ paths are relative to _Directory_ property
- All paths use / instead of \\
- Reference: 
https://clang.llvm.org/docs/JSONCompilationDatabase.html
https://clang.llvm.org/docs/HowToSetupToolingForLLVM.html

**Sample usage:**
`cd D:\advinst`
`cpt iis -file iiscore  -export-jsondb`
`clang-check D:\advinst\custact\iis\src\iis\IISCore.cpp -ast-dump -ast-dump-filter IISCore::Create`