### PR TITLE
Fix ignore-file mechanism not working when cache repository is active

### DIFF
--- a/ClangPowerTools/ClangPowerToolsShared/Tooling/v1/clang-build.ps1
+++ b/ClangPowerTools/ClangPowerToolsShared/Tooling/v1/clang-build.ps1
@@ -1323,6 +1323,18 @@ Function Process-Project( [Parameter(Mandatory=$true)] [string]       $vcxprojPa
 
   #-----------------------------------------------------------------------------------------------
   # FILTER LIST OF CPPs TO PROCESS
+  if ($global:cptFilesToProcess.Count -gt 0 -and $aCppToIgnore.Count -gt 0)
+  {
+    [System.Collections.Hashtable] $filteredCpps = @{}
+    foreach ($cpp in $global:cptFilesToProcess.Keys)
+    {
+      if ( ! (Should-IgnoreFile -file $cpp) )
+      {
+        $filteredCpps[$cpp] = $global:cptFilesToProcess[$cpp]
+      }
+    }
+    $global:cptFilesToProcess = $filteredCpps
+  }
 
   if ($global:cptFilesToProcess.Count -gt 0 -and $aCppToCompile.Count -gt 0)
   {

--- a/ClangPowerTools/ClangPowerToolsShared/Tooling/v1/psClang/msbuild-project-data.ps1
+++ b/ClangPowerTools/ClangPowerToolsShared/Tooling/v1/psClang/msbuild-project-data.ps1
@@ -118,11 +118,6 @@ Function Get-ProjectFilesToCompile()
         {
             foreach ($file in $matchedFiles)
             {
-                if ( (Should-IgnoreFile -file $file) )
-                {
-                    continue
-                }
-
                 $files += New-Object PsObject -Prop @{ "File"       = $file
                                                      ; "Properties" = $itemProps
                                                      }


### PR DESCRIPTION
The filter was being applied before the cache-save boundary