### PR TITLE
Update cpplatest flag to c++2b for LLVM 13 and newer

### DIFF
--- a/ClangPowerTools/ClangPowerToolsShared/Tooling/v1/clang-build.ps1
+++ b/ClangPowerTools/ClangPowerToolsShared/Tooling/v1/clang-build.ps1
@@ -679,8 +679,7 @@ Function Generate-Pch( [Parameter(Mandatory=$true)] [string]   $stdafxDir
                                   ,$kClangFlagNoUnusedArg
                                   ,$preprocessorDefinitions
                                   )
-  [int] $clangVer = Get-ClangVersion 
-  if ($clangVer -ge 11)
+  if ($kLLVMVersion -ge 11)
   {
     # this flag gets around 15% faster PCH compilation times
     # https://www.phoronix.com/scan.php?page=news_item&px=LLVM-Clang-11-PCH-Instant-Temp
@@ -1620,6 +1619,7 @@ if (![string]::IsNullOrEmpty($global:llvmLocation))
 {
   $env:Path += ";" + $global:llvmLocation
 }
+Set-Variable -name "kLLVMVersion" -value (Get-ClangVersion $clangToolWeNeed) -scope Global
 
 # initialize JSON compilation db support, if required
 if ($aExportJsonDB) 

--- a/ClangPowerTools/ClangPowerToolsShared/Tooling/v1/psClang/io.ps1
+++ b/ClangPowerTools/ClangPowerToolsShared/Tooling/v1/psClang/io.ps1
@@ -468,12 +468,12 @@ Function Exists-Command([Parameter(Mandatory = $true)][string] $command)
     }
 }
 
-Function Get-ClangVersion()
+Function Get-ClangVersion([Parameter(Mandatory = $true)][string] $toolToCheck)
 {
-    if (Exists-Command "clang++")
+    if (Exists-Command $toolToCheck)
     {
-        [string] $s = &"clang++" --version
-        $regexMatch = [regex]::match($s, 'clang version (\d+).')
+        [string] $s = &"$toolToCheck" --version
+        $regexMatch = [regex]::match($s, 'version (\d+).')
         if ($regexMatch)
         {
             return ($regexMatch.Groups[1].Value -as [int])

--- a/ClangPowerTools/ClangPowerToolsShared/Tooling/v1/psClang/msbuild-project-data.ps1
+++ b/ClangPowerTools/ClangPowerToolsShared/Tooling/v1/psClang/msbuild-project-data.ps1
@@ -197,6 +197,10 @@ Function Get-Project-CppStandard()
                   ; 'stdcpp17'     = 'c++17'
                   ; 'stdcpp20'     = 'c++20'
                   }
+    if ($kLLVMVersion -ge 13)
+    {
+        $cppStdMap['stdcpplatest'] = 'c++2b'
+    }
 
     [string] $cppStdClangValue = $cppStdMap[$cppStd]
 


### PR DESCRIPTION
If using LLVM 13 or newer, map `cpplatest` to `c++2b`

Source: https://clang.llvm.org/cxx_status.html#cxx23

Fixes #1132 