### PR TITLE
Bugfix: clang-format fails if .clang-format does not exist 

### DIFF
--- a/ClangPowerTools/ClangPowerTools.aip
+++ b/ClangPowerTools/ClangPowerTools.aip
@@ -8,7 +8,7 @@
     <ROW Name="License" Value="EXTENSIONS_FOLDER\Resources\LICENSE.txt" Type="1"/>
     <ROW Name="Locale" Value="1033" Type="0"/>
     <ROW Name="Name" Value="Clang Power Tools" Type="0" ValueLocId="*"/>
-    <ROW Name="Version" Value="9.1.0.1878" Type="0"/>
+    <ROW Name="Version" Value="9.1.0.1883" Type="0"/>
     <ROW Name="VsixLanguage" Value="en-US" Type="0"/>
   </COMPONENT>
   <COMPONENT cid="caphyon.advinst.msicomp.DictionaryComponent">

--- a/ClangPowerTools/ClangPowerTools/source.extension.vsixmanifest
+++ b/ClangPowerTools/ClangPowerTools/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="Caphyon.705559db-5755-43fa-a023-41a3b14d2935" Version="9.1.0.1878" Language="en-US" Publisher="Caphyon" />
+    <Identity Id="Caphyon.705559db-5755-43fa-a023-41a3b14d2935" Version="9.1.0.1883" Language="en-US" Publisher="Caphyon" />
     <DisplayName>Clang Power Tools</DisplayName>
     <Description xml:space="preserve">A tool bringing clang-tidy magic to Visual Studio C++ developers.</Description>
     <MoreInfo>http://www.clangpowertools.com/QaA</MoreInfo>

--- a/ClangPowerTools/ClangPowerToolsShared/Commands/FormatCommand.cs
+++ b/ClangPowerTools/ClangPowerToolsShared/Commands/FormatCommand.cs
@@ -263,7 +263,8 @@ namespace ClangPowerTools.Commands
 
     private bool IsFileStyleSelected(FormatSettingsModel formatSettings)
     {
-      return formatSettings.Style == ClangFormatStyle.file;
+      return formatSettings.Style == ClangFormatStyle.file && 
+        formatSettings.FallbackStyle == ClangFormatFallbackStyle.none;
     }
 
     private bool FileHasExtension(string filePath, string fileExtensions)


### PR DESCRIPTION
#1156 