### PR TITLE
Return to previous version of format on save

### DIFF
--- a/ClangPowerTools/ClangPowerTools.aip
+++ b/ClangPowerTools/ClangPowerTools.aip
@@ -8,7 +8,7 @@
     <ROW Name="License" Value="EXTENSIONS_FOLDER\Resources\LICENSE.txt" Type="1"/>
     <ROW Name="Locale" Value="1033" Type="0"/>
     <ROW Name="Name" Value="Clang Power Tools" Type="0" ValueLocId="*"/>
-    <ROW Name="Version" Value="9.4.0.2189" Type="0"/>
+    <ROW Name="Version" Value="9.4.0.2194" Type="0"/>
     <ROW Name="VsixLanguage" Value="en-US" Type="0"/>
   </COMPONENT>
   <COMPONENT cid="caphyon.advinst.msicomp.DictionaryComponent">

--- a/ClangPowerTools/ClangPowerTools.aip
+++ b/ClangPowerTools/ClangPowerTools.aip
@@ -8,7 +8,7 @@
     <ROW Name="License" Value="EXTENSIONS_FOLDER\Resources\LICENSE.txt" Type="1"/>
     <ROW Name="Locale" Value="1033" Type="0"/>
     <ROW Name="Name" Value="Clang Power Tools" Type="0" ValueLocId="*"/>
-    <ROW Name="Version" Value="9.4.0.2203" Type="0"/>
+    <ROW Name="Version" Value="9.4.1.2205" Type="0"/>
     <ROW Name="VsixLanguage" Value="en-US" Type="0"/>
   </COMPONENT>
   <COMPONENT cid="caphyon.advinst.msicomp.DictionaryComponent">

--- a/ClangPowerTools/ClangPowerTools.aip
+++ b/ClangPowerTools/ClangPowerTools.aip
@@ -8,7 +8,7 @@
     <ROW Name="License" Value="EXTENSIONS_FOLDER\Resources\LICENSE.txt" Type="1"/>
     <ROW Name="Locale" Value="1033" Type="0"/>
     <ROW Name="Name" Value="Clang Power Tools" Type="0" ValueLocId="*"/>
-    <ROW Name="Version" Value="9.4.0.2194" Type="0"/>
+    <ROW Name="Version" Value="9.4.0.2203" Type="0"/>
     <ROW Name="VsixLanguage" Value="en-US" Type="0"/>
   </COMPONENT>
   <COMPONENT cid="caphyon.advinst.msicomp.DictionaryComponent">

--- a/ClangPowerTools/ClangPowerTools/source.extension.vsixmanifest
+++ b/ClangPowerTools/ClangPowerTools/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="Caphyon.705559db-5755-43fa-a023-41a3b14d2935" Version="9.4.0.2194" Language="en-US" Publisher="Caphyon" />
+    <Identity Id="Caphyon.705559db-5755-43fa-a023-41a3b14d2935" Version="9.4.0.2203" Language="en-US" Publisher="Caphyon" />
     <DisplayName>Clang Power Tools</DisplayName>
     <Description xml:space="preserve">A tool bringing clang-tidy magic to Visual Studio C++ developers.</Description>
     <MoreInfo>http://www.clangpowertools.com/QaA</MoreInfo>

--- a/ClangPowerTools/ClangPowerTools/source.extension.vsixmanifest
+++ b/ClangPowerTools/ClangPowerTools/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="Caphyon.705559db-5755-43fa-a023-41a3b14d2935" Version="9.4.0.2189" Language="en-US" Publisher="Caphyon" />
+    <Identity Id="Caphyon.705559db-5755-43fa-a023-41a3b14d2935" Version="9.4.0.2194" Language="en-US" Publisher="Caphyon" />
     <DisplayName>Clang Power Tools</DisplayName>
     <Description xml:space="preserve">A tool bringing clang-tidy magic to Visual Studio C++ developers.</Description>
     <MoreInfo>http://www.clangpowertools.com/QaA</MoreInfo>

--- a/ClangPowerTools/ClangPowerTools/source.extension.vsixmanifest
+++ b/ClangPowerTools/ClangPowerTools/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="Caphyon.705559db-5755-43fa-a023-41a3b14d2935" Version="9.4.0.2203" Language="en-US" Publisher="Caphyon" />
+    <Identity Id="Caphyon.705559db-5755-43fa-a023-41a3b14d2935" Version="9.4.1.2205" Language="en-US" Publisher="Caphyon" />
     <DisplayName>Clang Power Tools</DisplayName>
     <Description xml:space="preserve">A tool bringing clang-tidy magic to Visual Studio C++ developers.</Description>
     <MoreInfo>http://www.clangpowertools.com/QaA</MoreInfo>

--- a/ClangPowerTools/ClangPowerToolsShared/ClangPowerToolsPackageImpl.cs
+++ b/ClangPowerTools/ClangPowerToolsShared/ClangPowerToolsPackageImpl.cs
@@ -33,6 +33,7 @@ namespace ClangPowerTools
     public const string PackageGuidString = "f564f9d3-01ae-493e-883b-18deebdb975e";
 
     private uint mHSolutionEvents = uint.MaxValue;
+    private RunningDocTableEvents mRunningDocTableEvents;
     private ErrorWindowController mErrorWindowController;
     private CommandController mCommandController;
 
@@ -80,7 +81,7 @@ namespace ClangPowerTools
         PowerShellWrapper.mOutputWindowController = new OutputWindowController();
         PowerShellWrapper.mOutputWindowController.Initialize(mPackage, vsOutputWindow);
 
-        CommandControllerInstance.CommandController.mRunningDocTableEvents = new RunningDocTableEvents(mPackage);
+        mRunningDocTableEvents = new RunningDocTableEvents(mPackage);
         mErrorWindowController = new ErrorWindowController(mPackage);
 
         #region Get Pointer to IVsSolutionEvents
@@ -424,8 +425,8 @@ namespace ClangPowerTools
       if (null != mCommandEvents)
         mCommandEvents.BeforeExecute += mCommandController.CommandEventsBeforeExecute;
 
-      if (null != CommandControllerInstance.CommandController.mRunningDocTableEvents)
-        CommandControllerInstance.CommandController.mRunningDocTableEvents.AfterSave += mCommandController.OnAfterSave;
+      if (null != mRunningDocTableEvents)
+        mRunningDocTableEvents.BeforeSave += mCommandController.OnBeforeSave;
 
       if (null != mDteEvents)
         mDteEvents.OnBeginShutdown += UnregisterFromEvents;
@@ -543,6 +544,9 @@ namespace ClangPowerTools
 
       if (null != mCommandEvents)
         mCommandEvents.BeforeExecute -= mCommandController.CommandEventsBeforeExecute;
+
+      if (null != mRunningDocTableEvents)
+        mRunningDocTableEvents.BeforeSave -= mCommandController.OnBeforeSave;
 
       if (null != mDteEvents)
         mDteEvents.OnBeginShutdown -= UnregisterFromEvents;

--- a/ClangPowerTools/ClangPowerToolsShared/Commands/CommandController.cs
+++ b/ClangPowerTools/ClangPowerToolsShared/Commands/CommandController.cs
@@ -862,7 +862,7 @@ namespace ClangPowerTools
       if (false == formatSettings.FormatOnSave)
         return;
 
-      if (false == Vsix.IsDocumentDirty(aDocument) && false == mFormatAfterTidyFlag)
+      if (currentCommand == CommandIds.kTidyFixId && false == Vsix.IsDocumentDirty(aDocument) && false == mFormatAfterTidyFlag)
         return;
 
       FormatCommand.Instance.FormatOnSave(aDocument);

--- a/ClangPowerTools/ClangPowerToolsShared/Commands/CommandController.cs
+++ b/ClangPowerTools/ClangPowerToolsShared/Commands/CommandController.cs
@@ -47,8 +47,6 @@ namespace ClangPowerTools
     public event EventHandler<EventArgs> ErrorDetectedEvent;
     public event EventHandler<EventArgs> HasEncodingErrorEvent;
 
-    public RunningDocTableEvents mRunningDocTableEvents;
-
     private bool mFormatted = false;
     private readonly Commands2 mCommand;
     private CommandUILocation commandUILocation;
@@ -815,33 +813,12 @@ namespace ClangPowerTools
       return VSConstants.S_OK;
     }
 
-    public void OnAfterSave(object sender, Document aDocument)
+    public void OnBeforeSave(object sender, Document aDocument)
     {
-      var formatSettings = SettingsProvider.FormatSettingsModel;
-
-      if (!formatSettings.FormatOnSave)
-        return;
-      if (mFormatted)
-      {
-        mFormatted = false;
-        return;
-      }
       StopBackgroundRunners();
+
       BeforeSaveClangTidyAsync(aDocument).SafeFireAndForget();
       BeforeSaveClangFormat(aDocument);
-      if (!mFormatted)
-      {
-        FormatCommand.Instance.FormatOnSave(aDocument);
-        mFormatted = true;
-      }
-      if (mRunningDocTableEvents is not null)
-      {
-        if (VsServiceProvider.TryGetService(typeof(DTE2), out object dte))
-        {
-          var dte2 = (DTE2)dte;
-          dte2.ExecuteCommand("File.SaveSelectedItems");
-        }
-      }
     }
 
     private async Task BeforeSaveClangTidyAsync(Document document)
@@ -876,8 +853,7 @@ namespace ClangPowerTools
       var formatSettings = SettingsProvider.FormatSettingsModel;
       var tidySettings = SettingsProvider.TidySettingsModel;
 
-      if (currentCommand == CommandIds.kTidyFixId && running && tidySettings.FormatAfterTidy &&
-          formatSettings.FormatOnSave)
+      if (currentCommand == CommandIds.kTidyFixId && running && tidySettings.FormatAfterTidy && formatSettings.FormatOnSave)
       {
         mFormatAfterTidyFlag = true;
         return;
@@ -885,6 +861,11 @@ namespace ClangPowerTools
 
       if (false == formatSettings.FormatOnSave)
         return;
+
+      if (false == Vsix.IsDocumentDirty(aDocument) && false == mFormatAfterTidyFlag)
+        return;
+
+      FormatCommand.Instance.FormatOnSave(aDocument);
     }
 
     public void CommandEventsBeforeExecute(string aGuid,

--- a/ClangPowerTools/ClangPowerToolsShared/Helpers/RunningDocTableEvents.cs
+++ b/ClangPowerTools/ClangPowerToolsShared/Helpers/RunningDocTableEvents.cs
@@ -18,11 +18,9 @@ namespace ClangPowerTools
     private RunningDocumentTable mRunningDocumentTable;
 
     public delegate void OnBeforeSaveHandler(object sender, Document document);
-    public delegate void OnAfterSaveHandler(object sender, Document document);
     public delegate void OnBeforeActiveDocumentChange(object sender, Document document);
 
     public event OnBeforeSaveHandler BeforeSave;
-    public event OnAfterSaveHandler AfterSave;
     public event OnBeforeActiveDocumentChange BeforeActiveDocumentChange;
 
     #endregion
@@ -68,26 +66,6 @@ namespace ClangPowerTools
 
     public int OnAfterSave(uint docCookie)
     {
-      try
-      {
-        if (null == AfterSave)
-          return VSConstants.S_OK;
-
-        var document = FindDocumentByCookie(docCookie);
-        if (null == document)
-          return VSConstants.S_OK;
-
-        bool acceptedExtension = ScriptConstants.kExtendedAcceptedFileExtensions.Contains(Path.GetExtension(document.Name));
-        if (acceptedExtension == false)
-          return VSConstants.S_OK;
-
-        AfterSave(this, document);
-      }
-      catch (Exception e)
-      {
-        MessageBox.Show("Error while running clang command on save. " + e.Message, "Clang Power Tools", MessageBoxButtons.OK, MessageBoxIcon.Error);
-      }
-
       return VSConstants.S_OK;
     }
 
@@ -112,7 +90,6 @@ namespace ClangPowerTools
     {
       return VSConstants.S_OK;
     }
-
 
     public int OnBeforeSave(uint docCookie)
     {

--- a/ClangPowerTools/ClangPowerToolsShared/MVVM/Views/ReleaseNotesView.xaml
+++ b/ClangPowerTools/ClangPowerToolsShared/MVVM/Views/ReleaseNotesView.xaml
@@ -75,7 +75,7 @@
                  HorizontalAlignment="Center"
                  FontSize="15"
                  Foreground="#3A3B40"
-                 Text="version 9.4" />
+                 Text="version 9.4.1" />
 
       <ListView Grid.Row="3"
                 Grid.Column="1"
@@ -100,7 +100,7 @@
         </ListView.ItemContainerStyle>
 
         <!--What's new-->
-        <TextBox Margin="5,20,0,0"
+        <!--<TextBox Margin="5,20,0,0"
                  HorizontalAlignment="Left"
                  Background="Transparent"
                  BorderThickness="0"
@@ -134,7 +134,7 @@
                  FontSize="16"
                  IsReadOnly="True"
                  Text="• LLVM 15.0.4"
-                 TextWrapping="Wrap" />
+                 TextWrapping="Wrap" />-->
         
         <!--Bug Fixes-->
         <TextBox Margin="5,20,0,0"
@@ -151,17 +151,17 @@
                  BorderThickness="0"
                  FontSize="16"
                  IsReadOnly="True"
-                 Text="• If you don't have LLVM installed manually, the process of auto-install fails"
+                 Text="• Format on save causes crashes on Visual Studio v17.4"
                  TextWrapping="Wrap" />
 
-        <TextBox Margin="15,15,0,0"
+        <!--<TextBox Margin="15,15,0,0"
                  HorizontalAlignment="Left"
                  Background="Transparent"
                  BorderThickness="0"
                  FontSize="16"
                  IsReadOnly="True"
                  Text="• Invalid link to tidy checks description"
-                 TextWrapping="Wrap" />
+                 TextWrapping="Wrap" />-->
         <!--<TextBox
           Margin="15,5,0,0"
           HorizontalAlignment="Left"


### PR DESCRIPTION
After Visual Studio [release 17.4](https://developercommunity.visualstudio.com/t/Visual-Studio-clears-dirty-flag-before-c/10124978) returning to the previous version of format on save will fix #1191 #1099 #1207 