### PR TITLE
Fix #1230

### DIFF
--- a/ClangPowerTools/ClangPowerToolsShared/Tooling/v1/psClang/msbuild-project-data.ps1
+++ b/ClangPowerTools/ClangPowerToolsShared/Tooling/v1/psClang/msbuild-project-data.ps1
@@ -153,10 +153,10 @@ Function Get-Project-SDKVer()
     }
 
     if ([string]::IsNullOrEmpty($WindowsTargetPlatformVersion))
-    { 
-        return "" 
-    } 
-    
+    {
+        return ""
+    }
+
     return $WindowsTargetPlatformVersion.Trim()
 }
 
@@ -379,9 +379,9 @@ Function Get-ProjectIncludeDirectories()
     {
         return @(Get-ProjectIncludesFromIncludePathVar)
     }
-    else 
+    else
     {
-        $returnArray += @(Get-ProjectIncludesFromIncludePathVar)    
+        $returnArray += @(Get-ProjectIncludesFromIncludePathVar)
     }
 
     return ( $returnArray | ForEach-Object { Remove-PathTrailingSlash -path $_ } )
@@ -499,9 +499,10 @@ Function Get-ProjectStdafxDir( [Parameter(Mandatory = $true)]  [string]   $pchHe
 
         foreach ($dir in $searchPool)
         {
-            [string] $stdafxPath = Canonize-Path -base $dir -child $pchHeaderName -ignoreErrors
-            if (![string]::IsNullOrEmpty($stdafxPath))
+            [string] $stdafxPathTest = Canonize-Path -base $dir -child $pchHeaderName -ignoreErrors
+            if (![string]::IsNullOrEmpty($stdafxPathTest))
             {
+                $stdafxPath = $dir
                 break
             }
         }
@@ -513,8 +514,9 @@ Function Get-ProjectStdafxDir( [Parameter(Mandatory = $true)]  [string]   $pchHe
     }
     else
     {
-        [string] $stdafxDir = Get-FileDirectory($stdafxPath)
-        return $stdafxDir
+        #[string] $stdafxDir = Get-FileDirectory($stdafxPath)
+        #return $stdafxDir
+        return $stdafxPath
     }
 }
 

--- a/ClangPowerTools/JSON/Schemas/Catalog/https%003A%002F%002Fgo.microsoft.com%002Ffwlink%002F%003Flinkid%003D835884
+++ b/ClangPowerTools/JSON/Schemas/Catalog/https%003A%002F%002Fgo.microsoft.com%002Ffwlink%002F%003Flinkid%003D835884
@@ -1,0 +1,4439 @@
+{
+  "$schema": "https://json.schemastore.org/schema-catalog.json",
+  "schemas": [
+    {
+      "name": "Common types for all schemas",
+      "description": "",
+      "fileMatch": [],
+      "url": "https://json.schemastore.org/base.json"
+    },
+    {
+      "name": "base-04",
+      "description": "Common types for draft-04-based schemas",
+      "fileMatch": [],
+      "url": "https://json.schemastore.org/base-04.json"
+    },
+    {
+      "name": "AnyWork Automation Configuration",
+      "description": "AnyWork Automation Configuration used to configure automation scripts on AnyWork",
+      "fileMatch": [".awc.yaml", ".awc.yml", ".awc.json", ".awc.jsonc", ".awc"],
+      "url": "https://json.schemastore.org/anywork-ac-1.1.json",
+      "versions": {
+        "1.0": "https://json.schemastore.org/anywork-ac-1.0.json"
+      }
+    },
+    {
+      "name": "@factorial/drupal-breakpoints-css",
+      "description": "JSON Schema for @factorial/drupal-breakpoints-css config file",
+      "fileMatch": ["breakpoints.config.yml"],
+      "url": "https://json.schemastore.org/factorial-drupal-breakpoints-css-0.2.0.json"
+    },
+    {
+      "name": ".adonisrc.json",
+      "description": "AdonisJS configuration file",
+      "fileMatch": [".adonisrc.json"],
+      "url": "https://raw.githubusercontent.com/adonisjs/application/master/adonisrc.schema.json"
+    },
+    {
+      "name": ".agripparc.json",
+      "description": "JSON schema for the Agrippa config file",
+      "fileMatch": [".agripparc.json", "agripparc.json"],
+      "url": "https://json.schemastore.org/agripparc-1.4.json",
+      "versions": {
+        "1.2": "https://json.schemastore.org/agripparc-1.2.json",
+        "1.3": "https://json.schemastore.org/agripparc-1.3.json",
+        "1.4": "https://json.schemastore.org/agripparc-1.4.json"
+      }
+    },
+    {
+      "name": ".aiproj.json",
+      "description": "Settings for project analysis by the application inspector",
+      "fileMatch": [".aiproj.json"],
+      "url": "https://json.schemastore.org/aiproj.json"
+    },
+    {
+      "name": "Airlock Microgateway",
+      "description": "Airlock Microgateway configuration schema",
+      "url": "https://json.schemastore.org/airlock-microgateway-3.2.json",
+      "fileMatch": [
+        "microgateway-config.yaml",
+        "microgateway-config.yml",
+        "airlock-microgateway-config.yaml",
+        "airlock-microgateway-config.yml"
+      ],
+      "versions": {
+        "3.0": "https://json.schemastore.org/airlock-microgateway-3.0.json",
+        "3.1": "https://json.schemastore.org/airlock-microgateway-3.1.json",
+        "3.2": "https://json.schemastore.org/airlock-microgateway-3.2.json"
+      }
+    },
+    {
+      "name": "Airplane task",
+      "description": "Schema for building Airplane tasks",
+      "fileMatch": ["*.task.json", "*.task.yaml", "*.task.yml"],
+      "url": "https://raw.githubusercontent.com/airplanedev/lib/main/pkg/deploy/taskdir/definitions/schema_0_3.json"
+    },
+    {
+      "name": "angular.json",
+      "description": "Angular configuration file",
+      "fileMatch": ["angular.json"],
+      "url": "https://raw.githubusercontent.com/angular/angular-cli/master/packages/angular/cli/lib/config/workspace-schema.json"
+    },
+    {
+      "name": ".angular-cli.json",
+      "description": "Angular CLI configuration file",
+      "fileMatch": [".angular-cli.json", "angular-cli.json"],
+      "url": "https://raw.githubusercontent.com/angular/angular-cli/v10.1.6/packages/angular/cli/lib/config/schema.json"
+    },
+    {
+      "name": "Ansible Execution Environment",
+      "description": "Ansible execution-environment.yml file",
+      "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/execution-environment.json",
+      "fileMatch": ["**/execution-environment.yml"]
+    },
+    {
+      "name": "Ansible Meta",
+      "description": "Ansible meta/main.yml file",
+      "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/meta.json",
+      "fileMatch": ["**/meta/main.yml"]
+    },
+    {
+      "name": "Ansible Meta Runtime",
+      "description": "Ansible meta/runtime.yml file",
+      "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/meta-runtime.json",
+      "fileMatch": ["**/meta/runtime.yml"]
+    },
+    {
+      "name": "Ansible Argument Specs",
+      "description": "Ansible meta/argument_specs.yml file",
+      "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/arg_specs.json",
+      "fileMatch": ["**/meta/argument_specs.yml"]
+    },
+    {
+      "name": "Ansible Requirements",
+      "description": "Ansible requirements file",
+      "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/requirements.json",
+      "fileMatch": ["requirements.yml"]
+    },
+    {
+      "name": "Ansible Vars File",
+      "description": "Ansible variables File",
+      "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/vars.json",
+      "fileMatch": [
+        "**/vars/*.yml",
+        "**/vars/*.yaml",
+        "**/defaults/*.yml",
+        "**/defaults/*.yaml",
+        "**/host_vars/*.yml",
+        "**/host_vars/*.yaml",
+        "**/group_vars/*.yml",
+        "**/group_vars/*.yaml"
+      ]
+    },
+    {
+      "name": "Ansible Tasks File",
+      "description": "Ansible tasks file",
+      "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/ansible.json#/$defs/tasks",
+      "fileMatch": [
+        "**/tasks/*.yml",
+        "**/tasks/*.yaml",
+        "**/handlers/*.yml",
+        "**/handlers/*.yaml"
+      ]
+    },
+    {
+      "name": "Ansible Playbook",
+      "description": "Ansible playbook files",
+      "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/ansible.json#/$defs/playbook",
+      "fileMatch": [
+        "playbook.yml",
+        "playbook.yaml",
+        "site.yml",
+        "site.yaml",
+        "**/playbooks/*.yml",
+        "**/playbooks/*.yaml"
+      ]
+    },
+    {
+      "name": "Ansible Inventory",
+      "description": "Ansible inventory files",
+      "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/inventory.json",
+      "fileMatch": ["inventory.yml", "inventory.yaml"]
+    },
+    {
+      "name": "Ansible Collection Galaxy",
+      "description": "Ansible Collection Galaxy metadata",
+      "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/galaxy.json",
+      "fileMatch": ["galaxy.yml"]
+    },
+    {
+      "name": "Ansible-lint Configuration",
+      "description": "Ansible-lint Configuration",
+      "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/ansible-lint-config.json",
+      "fileMatch": [".ansible-lint", "**/.config/ansible-lint.yml"]
+    },
+    {
+      "name": "Ansible Navigator Configuration",
+      "description": "Ansible Navigator Configuration",
+      "url": "https://raw.githubusercontent.com/ansible/ansible-navigator/main/src/ansible_navigator/data/ansible-navigator.json",
+      "fileMatch": [
+        ".ansible-navigator.json",
+        ".ansible-navigator.yaml",
+        ".ansible-navigator.yml",
+        "ansible-navigator.json",
+        "ansible-navigator.yaml",
+        "ansible-navigator.yml"
+      ]
+    },
+    {
+      "name": "apple-app-site-association",
+      "description": "Apple Universal Link, App Site Association",
+      "fileMatch": ["apple-app-site-association"],
+      "url": "https://json.schemastore.org/apple-app-site-association.json"
+    },
+    {
+      "name": "app-definition.yaml",
+      "description": "Appsemble app definition",
+      "fileMatch": ["app-definition.yaml"],
+      "url": "https://appsemble.app/api.json#/components/schemas/AppDefinition"
+    },
+    {
+      "name": ".appsemblerc.yaml",
+      "description": "Appsemble RC file",
+      "fileMatch": [".appsemblerc.yaml"],
+      "url": "https://gitlab.com/appsemble/appsemble/-/raw/HEAD/packages/cli/assets/appsemblerc.schema.json"
+    },
+    {
+      "name": "appsscript.json",
+      "description": "Google Apps Script manifest file",
+      "fileMatch": ["appsscript.json"],
+      "url": "https://json.schemastore.org/appsscript.json"
+    },
+    {
+      "name": "appsettings.json",
+      "description": "ASP.NET Core's configuration file",
+      "fileMatch": ["appsettings.json", "appsettings.*.json"],
+      "url": "https://json.schemastore.org/appsettings.json"
+    },
+    {
+      "name": "appveyor.yml",
+      "description": "AppVeyor CI configuration file",
+      "fileMatch": ["appveyor.yml"],
+      "url": "https://json.schemastore.org/appveyor.json"
+    },
+    {
+      "name": "architect.yml",
+      "description": "Architect.io Component Schema",
+      "fileMatch": [
+        "architect.yml",
+        "architect.yaml",
+        "*.architect.yml",
+        "*.architect.yaml"
+      ],
+      "url": "https://raw.githubusercontent.com/architect-team/architect-cli/main/src/dependency-manager/schema/architect.schema.json"
+    },
+    {
+      "name": "arc.json",
+      "description": "A JSON schema for OpenJS Architect",
+      "fileMatch": ["arc.json", "arc.yml", "arc.yaml"],
+      "url": "https://raw.githubusercontent.com/architect/parser/v2.3.0/arc-schema.json"
+    },
+    {
+      "name": "Argo Events",
+      "description": "Argo Events Event Sources and Sensors",
+      "url": "https://raw.githubusercontent.com/argoproj/argo-events/master/api/jsonschema/schema.json"
+    },
+    {
+      "name": "Argo Workflows",
+      "description": "Argo Workflow configuration file",
+      "url": "https://raw.githubusercontent.com/argoproj/argo-workflows/master/api/jsonschema/schema.json"
+    },
+    {
+      "name": "artifacthub-repo.yml",
+      "description": "Artifact Hub repository metadata file",
+      "fileMatch": ["artifacthub-repo.yml"],
+      "url": "https://json.schemastore.org/artifacthub-repo.json"
+    },
+    {
+      "name": "AssemblyScript",
+      "description": "AssemblyScript is TypeScript-like language that is compiled to WebAssembly (wasm).",
+      "fileMatch": ["asconfig.json"],
+      "url": "https://json.schemastore.org/asconfig-schema.json"
+    },
+    {
+      "name": "AsyncAPI",
+      "description": "A JSON Schema for validating AsyncAPI documentation files",
+      "fileMatch": [
+        "asyncapi.json",
+        "*asyncapi.json",
+        "asyncapi.yml",
+        "*asyncapi.yml",
+        "asyncapi.yaml",
+        "*asyncapi.yaml"
+      ],
+      "url": "https://www.asyncapi.com/schema-store/all.schema-store.json"
+    },
+    {
+      "name": "AsyncAPI Tool File",
+      "description": "A JSON Schema for validating AsyncAPI tool files",
+      "fileMatch": [".asyncapi-tool"],
+      "url": "https://raw.githubusercontent.com/asyncapi/website/master/scripts/tools/tools-schema.json"
+    },
+    {
+      "name": "Avro Avsc",
+      "description": "Avro Schema Avsc file",
+      "fileMatch": ["*.avsc"],
+      "url": "https://json.schemastore.org/avro-avsc.json"
+    },
+    {
+      "name": "Azure Device Update for IoT Hub import manifest",
+      "description": "Azure Device Update for IoT Hub import manifest schema",
+      "fileMatch": ["*.importmanifest.json"],
+      "url": "https://json.schemastore.org/azure-deviceupdate-import-manifest-5.0.json",
+      "versions": {
+        "4.0": "https://json.schemastore.org/azure-deviceupdate-import-manifest-4.0.json",
+        "5.0": "https://json.schemastore.org/azure-deviceupdate-import-manifest-5.0.json"
+      }
+    },
+    {
+      "name": "Azure Device Update for IoT Hub update manifest",
+      "description": "Azure Device Update for IoT Hub update manifest schema",
+      "fileMatch": ["*.updatemanifest.json"],
+      "url": "https://json.schemastore.org/azure-deviceupdate-update-manifest-5.json",
+      "versions": {
+        "4": "https://json.schemastore.org/azure-deviceupdate-update-manifest-4.json",
+        "5": "https://json.schemastore.org/azure-deviceupdate-update-manifest-5.json"
+      }
+    },
+    {
+      "name": "Azure IoT EdgeAgent deployment",
+      "description": "Azure IoT EdgeAgent deployment schema",
+      "url": "https://json.schemastore.org/azure-iot-edgeagent-deployment-1.1.json",
+      "versions": {
+        "1.0": "https://json.schemastore.org/azure-iot-edgeagent-deployment-1.0.json",
+        "1.1": "https://json.schemastore.org/azure-iot-edgeagent-deployment-1.1.json"
+      }
+    },
+    {
+      "name": "Azure IoT EdgeHub deployment",
+      "description": "Azure IoT EdgeHub deployment schema",
+      "url": "https://json.schemastore.org/azure-iot-edgehub-deployment-1.2.json",
+      "versions": {
+        "1.0": "https://json.schemastore.org/azure-iot-edgehub-deployment-1.0.json",
+        "1.1": "https://json.schemastore.org/azure-iot-edgehub-deployment-1.1.json",
+        "1.2": "https://json.schemastore.org/azure-iot-edgehub-deployment-1.2.json"
+      }
+    },
+    {
+      "name": "Azure IoT Edge deployment",
+      "description": "Azure IoT Edge deployment schema",
+      "url": "https://json.schemastore.org/azure-iot-edge-deployment-2.0.json",
+      "versions": {
+        "1.0": "https://json.schemastore.org/azure-iot-edge-deployment-1.0.json",
+        "1.1": "https://json.schemastore.org/azure-iot-edge-deployment-2.0.json"
+      }
+    },
+    {
+      "name": "Azure IoT Edge deployment template",
+      "description": "Azure IoT Edge deployment template schema",
+      "fileMatch": [
+        "deployment.template.json",
+        "deployment.debug.template.json"
+      ],
+      "url": "https://json.schemastore.org/azure-iot-edge-deployment-template-4.0.json",
+      "versions": {
+        "1.0": "https://json.schemastore.org/azure-iot-edge-deployment-template-1.0.json",
+        "1.1": "https://json.schemastore.org/azure-iot-edge-deployment-template-2.0.json",
+        "1.2": "https://json.schemastore.org/azure-iot-edge-deployment-template-3.0.json",
+        "1.3": "https://json.schemastore.org/azure-iot-edge-deployment-template-4.0.json"
+      }
+    },
+    {
+      "name": "Azure Pipelines",
+      "description": "Azure Pipelines YAML pipelines definition",
+      "fileMatch": ["azure-pipelines.yml", "azure-pipelines.yaml"],
+      "url": "https://raw.githubusercontent.com/microsoft/azure-pipelines-vscode/master/service-schema.json"
+    },
+    {
+      "name": "Foxx Manifest",
+      "description": "ArangoDB Foxx service manifest file",
+      "fileMatch": ["manifest.json"],
+      "url": "https://json.schemastore.org/foxx-manifest.json"
+    },
+    {
+      "name": "fly.io Schema",
+      "description": "Schema for fly.io, a cloud provider",
+      "fileMatch": ["fly.toml"],
+      "url": "https://json.schemastore.org/fly.json"
+    },
+    {
+      "name": ".asmdef",
+      "description": "Unity 3D assembly definition file",
+      "fileMatch": ["*.asmdef"],
+      "url": "https://json.schemastore.org/asmdef.json"
+    },
+    {
+      "name": "babelrc.json",
+      "description": "Babel configuration file",
+      "fileMatch": [".babelrc", ".babelrc.json", "babel.config.json"],
+      "url": "https://json.schemastore.org/babelrc.json"
+    },
+    {
+      "name": ".backportrc.json",
+      "description": "Backport configuration file",
+      "fileMatch": [".backportrc.json"],
+      "url": "https://json.schemastore.org/backportrc.json"
+    },
+    {
+      "name": "batect.yml",
+      "description": "Batect configuration file",
+      "fileMatch": ["batect.yml", "batect-bundle.yml"],
+      "url": "https://ide-integration.batect.dev/v1/configSchema.json"
+    },
+    {
+      "name": "bamboo-spec",
+      "description": "The Bamboo Specs allows you to define Bamboo configuration as code, and have corresponding plans/deployments created or updated automatically in Bamboo",
+      "url": "https://json.schemastore.org/bamboo-spec.json",
+      "fileMatch": ["**/bamboo-specs/*.yaml", "**/bamboo-specs/*.yml"]
+    },
+    {
+      "name": "beef-database-codegen",
+      "description": "Beef (Business Entity Execution Framework) database code-generation configuration.",
+      "url": "https://raw.githubusercontent.com/Avanade/Beef/master/tools/Beef.CodeGen.Core/Schema/database.beef.json",
+      "fileMatch": [
+        "database.beef.yaml",
+        "database.beef.yml",
+        "database.beef.json"
+      ]
+    },
+    {
+      "name": "beef-entity-codegen",
+      "description": "Beef (Business Entity Execution Framework) entity code-generation configuration.",
+      "url": "https://raw.githubusercontent.com/Avanade/Beef/master/tools/Beef.CodeGen.Core/Schema/entity.beef.json",
+      "fileMatch": [
+        "entity.beef.yaml",
+        "entity.beef.yml",
+        "entity.beef.json",
+        "refdata.beef.yaml",
+        "refdata.beef.yml",
+        "refdata.beef.json",
+        "datamodel.beef.yaml",
+        "datamodel.beef.yml",
+        "datamodel.beef.json"
+      ]
+    },
+    {
+      "name": "beef-database-v5-codegen",
+      "description": "Beef (Business Entity Execution Framework) database code-generation configuration (v5).",
+      "url": "https://raw.githubusercontent.com/Avanade/Beef/master/tools/Beef.CodeGen.Core/Schema/database.beef-5.json",
+      "fileMatch": [
+        "database.beef-5.yaml",
+        "database.beef-5.yml",
+        "database.beef-5.json"
+      ]
+    },
+    {
+      "name": "beef-entity-v5-codegen",
+      "description": "Beef (Business Entity Execution Framework) entity code-generation configuration (v5).",
+      "url": "https://raw.githubusercontent.com/Avanade/Beef/master/tools/Beef.CodeGen.Core/Schema/entity.beef-5.json",
+      "fileMatch": [
+        "entity.beef-5.yaml",
+        "entity.beef-5.yml",
+        "entity.beef-5.json",
+        "refdata.beef-5.yaml",
+        "refdata.beef-5.yml",
+        "refdata.beef-5.json",
+        "datamodel.beef-5.yaml",
+        "datamodel.beef-5.yml",
+        "datamodel.beef-5.json"
+      ]
+    },
+    {
+      "name": "bigquery-table",
+      "description": "BigQuery table schema",
+      "url": "https://json.schemastore.org/bigquery-table.json",
+      "fileMatch": ["*.bigquery.json"]
+    },
+    {
+      "name": "bitbucket-pipelines",
+      "description": "Bitbucket Pipelines CI/CD manifest schema",
+      "url": "https://bitbucket.org/atlassianlabs/atlascode/raw/main/resources/schemas/pipelines-schema.json",
+      "fileMatch": ["bitbucket-pipelines.yml"]
+    },
+    {
+      "name": "bitrise",
+      "description": "The configuration format of the Bitrise CLI. Bitrise is a collection of tools and services to help you with the development and automation of your software projects, with a main focus on mobile apps.",
+      "url": "https://json.schemastore.org/bitrise.json",
+      "fileMatch": ["bitrise.yml", "bitrise.yaml", "bitrise.json"]
+    },
+    {
+      "name": "bitrise-step",
+      "description": "Steps and Workflows are the heart of how Bitrise works. A Bitrise build is simply a series of Steps. Bitrise is a collection of tools and services to help you with the development and automation of your software projects, with a main focus on mobile apps.",
+      "url": "https://json.schemastore.org/bitrise-step.json",
+      "fileMatch": ["step.yml"]
+    },
+    {
+      "name": ".bootstraprc",
+      "description": "Webpack bootstrap-loader configuration file",
+      "fileMatch": [".bootstraprc"],
+      "url": "https://json.schemastore.org/bootstraprc.json"
+    },
+    {
+      "name": "bower.json",
+      "description": "Bower package description file",
+      "fileMatch": ["bower.json", ".bower.json"],
+      "url": "https://json.schemastore.org/bower.json"
+    },
+    {
+      "name": ".bowerrc",
+      "description": "Bower configuration file",
+      "fileMatch": [".bowerrc"],
+      "url": "https://json.schemastore.org/bowerrc.json"
+    },
+    {
+      "name": "behat.yml",
+      "description": "Behat configuration file",
+      "fileMatch": ["behat.yml", "*.behat.yml"],
+      "url": "https://json.schemastore.org/behat.json"
+    },
+    {
+      "name": "bozr.suite.json",
+      "description": "Bozr test suite file",
+      "fileMatch": [".suite.json", ".xsuite.json"],
+      "url": "https://json.schemastore.org/bozr.json"
+    },
+    {
+      "name": "browser.i18n.json",
+      "description": "browser.i18n messages.json translation file",
+      "fileMatch": ["messages.json"],
+      "url": "https://json.schemastore.org/browser.i18n.json"
+    },
+    {
+      "name": "bucklescript",
+      "description": "BuckleScript configuration file",
+      "fileMatch": ["bsconfig.json"],
+      "url": "https://raw.githubusercontent.com/rescript-lang/rescript-compiler/master/docs/docson/build-schema.json"
+    },
+    {
+      "name": "Build Info",
+      "description": "Build Info is the metadata of a build. It includes all the details about the build broken down into segments that include version history, artifacts, project modules, dependencies, and everything that was required to create the build.",
+      "fileMatch": ["*buildinfo*.json", "*build-info*.json", "*.buildinfo"],
+      "url": "https://raw.githubusercontent.com/jfrog/build-info-go/main/buildinfo-schema.json"
+    },
+    {
+      "name": "Bukkit plugin.yml",
+      "description": "Schema for Minecraft Bukkit plugin description files",
+      "fileMatch": ["plugin.yml"],
+      "url": "https://json.schemastore.org/bukkit-plugin.json"
+    },
+    {
+      "name": "Buildkite",
+      "description": "Schema for Buildkite pipeline.yml files",
+      "fileMatch": [
+        "buildkite.yml",
+        "buildkite.yaml",
+        "buildkite.json",
+        "buildkite.*.yml",
+        "buildkite.*.yaml",
+        "buildkite.*.json",
+        "**/.buildkite/pipeline.yml",
+        "**/.buildkite/pipeline.yaml",
+        "**/.buildkite/pipeline.json",
+        "**/.buildkite/pipeline.*.yml",
+        "**/.buildkite/pipeline.*.yaml",
+        "**/.buildkite/pipeline.*.json"
+      ],
+      "url": "https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json"
+    },
+    {
+      "name": ".build.yml",
+      "description": "Sourcehut Build Manifest",
+      "fileMatch": [".build.yml"],
+      "url": "https://json.schemastore.org/sourcehut-build-0.65.0.json",
+      "versions": {
+        "0.41.2": "https://json.schemastore.org/sourcehut-build-0.41.2.json",
+        "0.65.0": "https://json.schemastore.org/sourcehut-build-0.65.0.json"
+      }
+    },
+    {
+      "name": "bundleconfig.json",
+      "description": "Schema for bundleconfig.json files",
+      "fileMatch": ["bundleconfig.json"],
+      "url": "https://json.schemastore.org/bundleconfig.json"
+    },
+    {
+      "name": "BungeeCord plugin.yml",
+      "description": "Schema for BungeeCord plugin description files",
+      "fileMatch": ["plugin.yml", "bungee.yml"],
+      "url": "https://json.schemastore.org/bungee-plugin.json"
+    },
+    {
+      "name": "block.json",
+      "description": "Schema WordPress block.json files",
+      "fileMatch": ["block.json"],
+      "url": "https://schemas.wp.org/trunk/block.json",
+      "versions": {
+        "trunk": "https://raw.githubusercontent.com/WordPress/gutenberg/trunk/schemas/json/block.json"
+      }
+    },
+    {
+      "name": "Block Protocol Metadata",
+      "description": "Schema for Block Metadata in Block Protocol",
+      "fileMatch": ["block-metadata.json"],
+      "url": "https://blockprotocol.org/schemas/block-metadata.json"
+    },
+    {
+      "name": "BX CI",
+      "description": "CI configuration for Amdocs Bill Experience projects",
+      "url": "https://json.schemastore.org/bxci.schema-2.x.json",
+      "fileMatch": ["**/bxci.yaml", "**/bxci.yml"],
+      "versions": {
+        "1.0": "https://json.schemastore.org/bxci.schema-1.0.json",
+        "1.0.1": "https://json.schemastore.org/bxci.schema-1.0.1.json",
+        "2.0.0": "https://json.schemastore.org/bxci.schema-2.0.0.json",
+        "2.x": "https://json.schemastore.org/bxci.schema-2.x.json"
+      }
+    },
+    {
+      "name": "Better Scripts",
+      "description": "Better scripts configuration file",
+      "fileMatch": [
+        "scripts.json",
+        "better-scripts.json",
+        ".better-scriptsrc",
+        ".better-scriptsrc.json"
+      ],
+      "url": "https://raw.githubusercontent.com/iamyoki/better-scripts/main/lib/schema.json"
+    },
+    {
+      "name": "CMake Presets",
+      "description": "Schema for CMake Presets",
+      "fileMatch": ["CMakePresets.json", "CMakeUserPresets.json"],
+      "url": "https://raw.githubusercontent.com/Kitware/CMake/master/Help/manual/presets/schema.json"
+    },
+    {
+      "name": "Calqulus pipeline",
+      "description": "Schema for Qualisys Calqulus pipeline",
+      "fileMatch": ["*.calqulus.yaml", "*.calqulus.yml"],
+      "url": "https://raw.githubusercontent.com/qualisys/qualisys-schemas/master/calqulus-pipeline.schema.json"
+    },
+    {
+      "name": "Camel YAML DSL",
+      "description": "Schema for Camel YAML DSL",
+      "fileMatch": ["*.camel.yaml", "*.camelk.yaml"],
+      "url": "https://raw.githubusercontent.com/apache/camel/main/dsl/camel-yaml-dsl/camel-yaml-dsl/src/generated/resources/schema/camel-yaml-dsl.json"
+    },
+    {
+      "name": "Carafe",
+      "description": "Schema for Carafe compatible JavaScript Bundles",
+      "url": "https://carafe.fm/schema/draft-02/bundle.schema.json",
+      "versions": {
+        "draft-02": "https://carafe.fm/schema/draft-02/bundle.schema.json",
+        "draft-01": "https://carafe.fm/schema/draft-01/bundle.schema.json"
+      }
+    },
+    {
+      "name": "Cargo Config Schema",
+      "description": "Configuration for Cargo, the Rust package manager and build tool",
+      "fileMatch": ["Cargo.toml"],
+      "url": "https://json.schemastore.org/cargo.json"
+    },
+    {
+      "name": "Cargo Make",
+      "description": "Schema for cargo-make, a Rust task runner and build tool",
+      "fileMatch": ["Makefile.toml"],
+      "url": "https://json.schemastore.org/cargo-make.json"
+    },
+    {
+      "name": "Catalog Info Backstage",
+      "description": "Schema for Backstage Catalog Info",
+      "url": "https://json.schemastore.org/catalog-info.json",
+      "fileMatch": ["catalog-info.yaml"]
+    },
+    {
+      "name": "CityJSON",
+      "description": "Schema for the representation of 3D city models",
+      "url": "https://raw.githubusercontent.com/cityjson/specs/master/schemas/cityjson.min.schema.json"
+    },
+    {
+      "name": "Conjure",
+      "description": "Conjure Human-Readable Format",
+      "url": "https://raw.githubusercontent.com/palantir/conjure/master/conjure.schema.json",
+      "fileMatch": ["**/conjure/**.yml"]
+    },
+    {
+      "name": "CNC Codes JSON Schema",
+      "description": "Schema definition for G/M codes for Machine Tools or 3D Printers",
+      "fileMatch": ["*.cncc.json"],
+      "url": "https://appliedengdesign.github.io/cnccodes-json-schema/draft/2022-07/schema",
+      "versions": {
+        "latest": "https://appliedengdesign.github.io/cnccodes-json-schema/draft/2022-07/schema",
+        "2022-07": "https://appliedengdesign.github.io/cnccodes-json-schema/draft/2022-07/schema",
+        "2022-06": "https://appliedengdesign.github.io/cnccodes-json-schema/draft/2022-06/schema"
+      }
+    },
+    {
+      "name": "Commandbox Box.json",
+      "description": "Box.json Schema used with Commandbox cli, cfml web servers and modules.",
+      "url": "https://raw.githubusercontent.com/Ortus-Solutions/vscode-commandbox/master/resources/schemas/box.schema.json"
+    },
+    {
+      "name": "Commandbox Server.json",
+      "description": "Server.json Schema used with Commandbox cfml web servers.",
+      "url": "https://raw.githubusercontent.com/Ortus-Solutions/vscode-commandbox/master/resources/schemas/server.schema.json"
+    },
+    {
+      "name": "dbt Project",
+      "description": "Schema for dbt project configurations",
+      "fileMatch": ["dbt_project.yml"],
+      "url": "https://raw.githubusercontent.com/dbt-labs/dbt-jsonschema/main/schemas/dbt_project.json"
+    },
+    {
+      "name": "Deadpendency Config Schema",
+      "description": "Schema for Deadpendency config, a dependency management GitHub app",
+      "fileMatch": [
+        "**/.github/deadpendency.yaml",
+        "**/.deadpendency/config.yaml"
+      ],
+      "url": "https://json.schemastore.org/deadpendency.json"
+    },
+    {
+      "name": "Dein Config Schema",
+      "description": "Schema for Dein.vim, a Vim/Neovim plugin manager",
+      "fileMatch": ["dein.toml"],
+      "url": "https://json.schemastore.org/dein.json"
+    },
+    {
+      "name": "Drupal Breakpoints Schema",
+      "description": "A Drupal schema for breakpoints",
+      "fileMatch": ["*.breakpoints.yml"],
+      "url": "https://json.schemastore.org/drupal-breakpoints.json"
+    },
+    {
+      "name": "Drupal Info Schema",
+      "description": "A Drupal schema for info",
+      "fileMatch": ["*.info.yml"],
+      "url": "https://json.schemastore.org/drupal-info.json"
+    },
+    {
+      "name": "Drupal Layouts Schema",
+      "description": "A Drupal schema for layouts",
+      "fileMatch": ["*.layouts.yml"],
+      "url": "https://json.schemastore.org/drupal-layouts.json"
+    },
+    {
+      "name": "Drupal Libraries Schema",
+      "description": "A Drupal schema for libraries",
+      "fileMatch": ["*.libraries.yml"],
+      "url": "https://json.schemastore.org/drupal-libraries.json"
+    },
+    {
+      "name": "Drupal Links Action Schema",
+      "description": "A Drupal schema for action links",
+      "fileMatch": ["*.links.action.yml"],
+      "url": "https://json.schemastore.org/drupal-links-action.json"
+    },
+    {
+      "name": "Drupal Links Contextual Schema",
+      "description": "A Drupal schema for contextual links",
+      "fileMatch": ["*.links.contextual.yml"],
+      "url": "https://json.schemastore.org/drupal-links-contextual.json"
+    },
+    {
+      "name": "Drupal Links Menu Schema",
+      "description": "A Drupal schema for menu links",
+      "fileMatch": ["*.links.menu.yml"],
+      "url": "https://json.schemastore.org/drupal-links-menu.json"
+    },
+    {
+      "name": "Drupal Links Task Schema",
+      "description": "A Drupal schema for task links",
+      "fileMatch": ["*.links.task.yml"],
+      "url": "https://json.schemastore.org/drupal-links-task.json"
+    },
+    {
+      "name": "Drupal Migration Schema",
+      "description": "A Drupal schema for migration",
+      "fileMatch": ["*.migration.*.yml", "**/migrations/*.yml"],
+      "url": "https://json.schemastore.org/drupal-migration.json"
+    },
+    {
+      "name": "Drupal Permissions Schema",
+      "description": "A Drupal schema for permissions",
+      "fileMatch": ["*.permissions.yml"],
+      "url": "https://json.schemastore.org/drupal-permissions.json"
+    },
+    {
+      "name": "Drupal Routing Schema",
+      "description": "A Drupal schema for routing",
+      "fileMatch": ["*.routing.yml"],
+      "url": "https://json.schemastore.org/drupal-routing.json"
+    },
+    {
+      "name": "Drupal Config Schema",
+      "description": "A Drupal schema for config",
+      "fileMatch": ["**/config/schema/*.schema.yml"],
+      "url": "https://json.schemastore.org/drupal-config.json"
+    },
+    {
+      "name": "Drupal Services Schema",
+      "description": "A Drupal schema for services",
+      "fileMatch": ["*.services.yml"],
+      "url": "https://json.schemastore.org/drupal-services.json"
+    },
+    {
+      "name": "Helm Chart.yaml",
+      "description": "The Chart.yaml file is required for a chart.",
+      "fileMatch": ["Chart.yaml"],
+      "url": "https://json.schemastore.org/chart.json"
+    },
+    {
+      "name": "Helm Chart.lock",
+      "description": "The Chart.lock file locks dependencies from Chart.yaml",
+      "fileMatch": ["Chart.lock"],
+      "url": "https://json.schemastore.org/chart-lock.json"
+    },
+    {
+      "name": "CircleCI config.yml",
+      "description": "Schema for CircleCI config files",
+      "fileMatch": ["**/.circleci/config.yml"],
+      "url": "https://json.schemastore.org/circleciconfig.json"
+    },
+    {
+      "name": "Code Climate",
+      "description": "Configuration file as an alternative for configuring your repository in the settings page.",
+      "fileMatch": [".codeclimate.yml", ".codeclimate.json"],
+      "url": "https://json.schemastore.org/codeclimate.json"
+    },
+    {
+      "name": ".cirrus.yml",
+      "description": "Cirrus CI configuration files",
+      "fileMatch": [".cirrus.yml"],
+      "url": "https://json.schemastore.org/cirrus.json"
+    },
+    {
+      "name": ".clasp.json",
+      "description": "Google Apps Script CLI project file",
+      "fileMatch": [".clasp.json"],
+      "url": "https://json.schemastore.org/clasp.json"
+    },
+    {
+      "name": "clangd",
+      "description": "Clang language server daemon",
+      "fileMatch": [".clangd", ".clangd.yml", ".clangd.yaml"],
+      "url": "https://json.schemastore.org/clangd.json"
+    },
+    {
+      "name": "cloudify",
+      "description": "Cloudify Blueprint",
+      "fileMatch": ["*.cfy.yaml"],
+      "url": "https://json.schemastore.org/cloudify.json"
+    },
+    {
+      "name": "cloud-init: cloud-config userdata JSON schema",
+      "description": "JSON schema for #cloud-config userdata YAML",
+      "fileMatch": [
+        "cloudconfig.yaml",
+        "cloud-config.yaml",
+        "*.cloudconfig.yaml",
+        "*.cloud-config.yaml"
+      ],
+      "url": "https://raw.githubusercontent.com/canonical/cloud-init/main/cloudinit/config/schemas/versions.schema.cloud-config.json"
+    },
+    {
+      "name": "codemagic",
+      "description": "JSON schema for Codemagic CI/CD file configuration",
+      "fileMatch": ["codemagic.yaml", "codemagic.yml"],
+      "url": "https://codemagic.io/codemagic-schema.json"
+    },
+    {
+      "name": "Codux",
+      "description": "Codux configuration file",
+      "fileMatch": ["codux.config.json"],
+      "url": "https://wixplosives.github.io/codux-config-schema/codux.config.schema.json"
+    },
+    {
+      "name": "JSON schema for Codecov configuration files",
+      "description": "Schema for codecov.yml files.",
+      "fileMatch": [".codecov.yml", "codecov.yml"],
+      "url": "https://json.schemastore.org/codecov.json"
+    },
+    {
+      "name": "JSON schema for CodeShip Pro services configuration files",
+      "description": "Schema for codeship-services.yml files.",
+      "fileMatch": ["codeship-services.yml"],
+      "url": "https://json.schemastore.org/codeship-services.json"
+    },
+    {
+      "name": "JSON schema for CodeShip Pro steps configuration files",
+      "description": "Schema for codeship-steps.yml files.",
+      "fileMatch": ["codeship-steps.yml"],
+      "url": "https://json.schemastore.org/codeship-steps.json"
+    },
+    {
+      "name": "Vercel",
+      "description": "Vercel configuration file",
+      "fileMatch": ["vercel.json"],
+      "url": "https://openapi.vercel.sh/vercel.json"
+    },
+    {
+      "name": "VSCode Code Snippets",
+      "description": "Schema for code snippet files in visual studio code extensions",
+      "fileMatch": ["*.code-snippets"],
+      "url": "https://raw.githubusercontent.com/Yash-Singh1/vscode-snippets-json-schema/main/schema.json"
+    },
+    {
+      "name": "compilerconfig.json",
+      "description": "Schema for compilerconfig.json files",
+      "fileMatch": ["compilerconfig.json"],
+      "url": "https://json.schemastore.org/compilerconfig.json"
+    },
+    {
+      "name": "compile_commands.json",
+      "description": "LLVM compilation database",
+      "fileMatch": ["compile_commands.json"],
+      "url": "https://json.schemastore.org/compile-commands.json"
+    },
+    {
+      "name": "commands.json",
+      "description": "Config file for Command Task Runner",
+      "fileMatch": ["commands.json"],
+      "url": "https://json.schemastore.org/commands.json"
+    },
+    {
+      "name": "Common Catalog Schema",
+      "description": "Universal schema for all catalog data focused on transformations and relationships",
+      "fileMatch": [
+        "*.cat.json",
+        "*.catalog.json",
+        "*.cat.yml",
+        "*.catalog.yml"
+      ],
+      "url": "https://raw.githubusercontent.com/howlowck/common-catalog-schema/main/schema-versions.json"
+    },
+    {
+      "name": "cosmos.config.json",
+      "description": "React Cosmos configuration file",
+      "fileMatch": ["cosmos.config.json"],
+      "url": "https://json.schemastore.org/cosmos-config.json"
+    },
+    {
+      "name": "Chrome Extension",
+      "description": "Google Chrome extension manifest file",
+      "url": "https://json.schemastore.org/chrome-manifest.json"
+    },
+    {
+      "name": "chutzpah.json",
+      "description": "Chutzpah configuration file",
+      "fileMatch": ["chutzpah.json"],
+      "url": "https://json.schemastore.org/chutzpah.json"
+    },
+    {
+      "name": "contentmanifest.json",
+      "description": "Visual Studio manifest injection file",
+      "fileMatch": ["contentmanifest.json"],
+      "url": "https://json.schemastore.org/vsix-manifestinjection.json"
+    },
+    {
+      "name": "cloud-sdk-pipeline-config-schema",
+      "description": "SAP Cloud SDK Pipeline configuration",
+      "fileMatch": ["pipeline_config.yml"],
+      "url": "https://json.schemastore.org/cloud-sdk-pipeline-config-schema.json"
+    },
+    {
+      "name": "cloudbuild.json",
+      "description": "Google Cloud Build configuration file",
+      "fileMatch": [
+        "cloudbuild.json",
+        "cloudbuild.yaml",
+        "cloudbuild.yml",
+        "*.cloudbuild.json",
+        "*.cloudbuild.yaml",
+        "*.cloudbuild.yml"
+      ],
+      "url": "https://json.schemastore.org/cloudbuild.json"
+    },
+    {
+      "name": "Google Cloud Workflows",
+      "description": "Google Cloud Workflows configuration file",
+      "fileMatch": [
+        "workflows.json",
+        "workflows.yaml",
+        "workflows.yml",
+        "*.workflows.json",
+        "*.workflows.yaml",
+        "*.workflows.yml"
+      ],
+      "url": "https://json.schemastore.org/workflows.json"
+    },
+    {
+      "name": "AWS CDK cdk.json",
+      "description": "Schema for AWS CDK context files",
+      "url": "https://json.schemastore.org/cdk.json",
+      "fileMatch": ["cdk.json"]
+    },
+    {
+      "name": "AWS CloudFormation",
+      "description": "AWS CloudFormation provides a common language for you to describe and provision all the infrastructure resources in your cloud environment.",
+      "fileMatch": [
+        "*.cf.json",
+        "*.cf.yml",
+        "*.cf.yaml",
+        "cloudformation.json",
+        "cloudformation.yml",
+        "cloudformation.yaml"
+      ],
+      "url": "https://raw.githubusercontent.com/awslabs/goformation/master/schema/cloudformation.schema.json"
+    },
+    {
+      "name": "AWS CloudFormation Serverless Application Model (SAM)",
+      "description": "The AWS Serverless Application Model (AWS SAM, previously known as Project Flourish) extends AWS CloudFormation to provide a simplified way of defining the Amazon API Gateway APIs, AWS Lambda functions, and Amazon DynamoDB tables needed by your serverless application.",
+      "fileMatch": [
+        "serverless.template",
+        "*.sam.json",
+        "*.sam.yml",
+        "*.sam.yaml",
+        "sam.json",
+        "sam.yml",
+        "sam.yaml"
+      ],
+      "url": "https://raw.githubusercontent.com/awslabs/goformation/master/schema/sam.schema.json"
+    },
+    {
+      "name": "Citation File Format",
+      "description": "A YAML file with citation metadata for software or datasets.",
+      "fileMatch": ["CITATION.cff"],
+      "url": "https://citation-file-format.github.io/1.2.0/schema.json"
+    },
+    {
+      "name": "coffeelint.json",
+      "description": "CoffeeLint configuration file",
+      "fileMatch": ["coffeelint.json"],
+      "url": "https://json.schemastore.org/coffeelint.json"
+    },
+    {
+      "name": "composer.json",
+      "description": "PHP Composer configuration file",
+      "fileMatch": ["composer.json"],
+      "url": "https://raw.githubusercontent.com/composer/composer/main/res/composer-schema.json"
+    },
+    {
+      "name": "component.json",
+      "description": "Web component file",
+      "fileMatch": ["component.json"],
+      "url": "https://json.schemastore.org/component.json"
+    },
+    {
+      "name": "component-detection-manifest.json",
+      "description": "Component Detection manifest",
+      "fileMatch": ["cdmanifest.json", "cgmanifest.json"],
+      "url": "https://json.schemastore.org/component-detection-manifest.json"
+    },
+    {
+      "name": "config.json",
+      "description": "ASP.NET project config file",
+      "fileMatch": ["config.json"],
+      "url": "https://json.schemastore.org/config.json"
+    },
+    {
+      "name": "contribute.json",
+      "description": "A JSON schema for open-source project contribution data by Mozilla",
+      "fileMatch": ["contribute.json"],
+      "url": "https://raw.githubusercontent.com/mozilla/contribute.json/master/schema.json"
+    },
+    {
+      "name": "crowdin.yml",
+      "description": "A JSON schema to configure Crowdin, a crowd-translation platform. See https://support.crowdin.com/configuration-file/.",
+      "fileMatch": ["**/crowdin.yml"],
+      "url": "https://json.schemastore.org/crowdin.json"
+    },
+    {
+      "name": "cypress.json",
+      "description": "Cypress.io test runner configuration file",
+      "fileMatch": ["cypress.json"],
+      "url": "https://on.cypress.io/cypress.schema.json"
+    },
+    {
+      "name": ".creatomic",
+      "description": "A config for Atomic Design 4 React generator",
+      "fileMatch": [".creatomic"],
+      "url": "https://json.schemastore.org/creatomic.json"
+    },
+    {
+      "name": "cspell",
+      "description": "JSON schema for cspell configuration file",
+      "fileMatch": [
+        ".cspell.json",
+        "cspell.json",
+        ".cSpell.json",
+        "cSpell.json",
+        "cspell.config.json",
+        "cspell.config.yaml",
+        "cspell.config.yml",
+        "cspell.yaml",
+        "cspell.yml"
+      ],
+      "url": "https://raw.githubusercontent.com/streetsidesoftware/cspell/main/packages/cspell-types/cspell.schema.json"
+    },
+    {
+      "name": ".csscomb.json",
+      "description": "A JSON schema CSS Comb's configuration file",
+      "fileMatch": [".csscomb.json"],
+      "url": "https://json.schemastore.org/csscomb.json"
+    },
+    {
+      "name": ".csslintrc",
+      "description": "A JSON schema CSS Lint's configuration file",
+      "fileMatch": [".csslintrc"],
+      "url": "https://json.schemastore.org/csslintrc.json"
+    },
+    {
+      "name": "Dart build configuration",
+      "description": "Configuration for Dart's build system",
+      "url": "https://json.schemastore.org/dart-build.json"
+    },
+    {
+      "name": "Dart test config",
+      "description": "Configuration for Dart's test package",
+      "fileMatch": ["dart_test.yaml"],
+      "url": "https://json.schemastore.org/dart-test.json"
+    },
+    {
+      "name": "DashLord configuration",
+      "description": "Configuration for DashLord",
+      "fileMatch": ["dashlord.yaml", "dashlord.yml"],
+      "url": "https://raw.githubusercontent.com/socialgouv/dashlord/main/schema.json"
+    },
+    {
+      "name": "datalogic-scan2deploy-android",
+      "description": "Datalogic Scan2Deploy Android file",
+      "fileMatch": [".dla.json"],
+      "url": "https://json.schemastore.org/datalogic-scan2deploy-android.json"
+    },
+    {
+      "name": "datalogic-scan2deploy-ce",
+      "description": "Datalogic Scan2Deploy CE file",
+      "fileMatch": [".dlc.json"],
+      "url": "https://json.schemastore.org/datalogic-scan2deploy-ce.json"
+    },
+    {
+      "name": "debugsettings.json",
+      "description": "A JSON schema for the ASP.NET DebugSettings.json files",
+      "fileMatch": ["debugsettings.json"],
+      "url": "https://json.schemastore.org/debugsettings.json"
+    },
+    {
+      "name": "Deno",
+      "description": "A JSON representation of a Deno configuration file.",
+      "fileMatch": ["deno.json", "deno.jsonc"],
+      "url": "https://raw.githubusercontent.com/denoland/deno/main/cli/schemas/config-file.v1.json"
+    },
+    {
+      "name": "dependabot.json",
+      "description": "A JSON schema for the Dependabot config.yml files",
+      "fileMatch": ["**/.dependabot/config.yml"],
+      "url": "https://json.schemastore.org/dependabot.json"
+    },
+    {
+      "name": "dependabot-v2.json",
+      "description": "A JSON schema for the GitHub Action's dependabot.yml files",
+      "fileMatch": ["**/.github/dependabot.yml"],
+      "url": "https://json.schemastore.org/dependabot-2.0.json"
+    },
+    {
+      "name": "Deployer Recipe",
+      "description": "A JSON schema for Deployer yaml recipes",
+      "fileMatch": ["deploy.yaml", "deploy.yml"],
+      "url": "https://raw.githubusercontent.com/deployphp/deployer/master/src/schema.json"
+    },
+    {
+      "name": "detekt.yml",
+      "description": "Detekt Configuration File schema",
+      "fileMatch": ["detekt.yml", "detekt.yaml"],
+      "url": "https://json.schemastore.org/detekt-1.22.0.json",
+      "versions": {
+        "1.14.1": "https://json.schemastore.org/detekt-1.14.1.json",
+        "1.22.0": "https://json.schemastore.org/detekt-1.22.0.json"
+      }
+    },
+    {
+      "name": "Discord Webhook",
+      "description": "Execute Discord Webhook JSON Schema",
+      "url": "https://raw.githubusercontent.com/AxoCode/json-schema/master/discord/webhook.json"
+    },
+    {
+      "name": "dockerd.json",
+      "description": "Docker daemon configuration",
+      "fileMatch": ["dockerd.json", "docker.json"],
+      "url": "https://json.schemastore.org/dockerd.json"
+    },
+    {
+      "name": "docker-seq schema",
+      "description": "Schema for docker-seq.\n\nSee at: https://gitlab.com/sbenv/veroxis/docker-seq",
+      "fileMatch": [
+        "docker-seq.yaml",
+        "docker-seq.json",
+        "docker-seq.yml",
+        "*.docker-seq.yaml",
+        "*.docker-seq.json",
+        "*.docker-seq.yml"
+      ],
+      "url": "https://gitlab.com/sbenv/veroxis/docker-seq/-/raw/HEAD/docker-seq.schema.json"
+    },
+    {
+      "name": "docfx.json",
+      "description": "A JSON schema for DocFx configuration files",
+      "fileMatch": ["docfx.json"],
+      "url": "https://json.schemastore.org/docfx.json"
+    },
+    {
+      "name": "Dolittle Artifacts",
+      "description": "A JSON schema for a Dolittle bounded context's artifacts",
+      "fileMatch": ["**/.dolittle/artifacts.json"],
+      "url": "https://raw.githubusercontent.com/dolittle/DotNET.SDK/v5.0.0/Schemas/Artifacts.Configuration/artifacts.json"
+    },
+    {
+      "name": "Dolittle Bounded Context Configuration",
+      "description": "A JSON schema for Dolittle application's bounded context configuration",
+      "fileMatch": ["bounded-context.json"],
+      "url": "https://raw.githubusercontent.com/dolittle/Runtime/master/Schemas/Applications.Configuration/bounded-context.json"
+    },
+    {
+      "name": "Dolittle Event Horizons Configuration",
+      "description": "A JSON schema for a Dolittle bounded context's event horizon configurations",
+      "fileMatch": ["**/.dolittle/event-horizons.json"],
+      "url": "https://raw.githubusercontent.com/dolittle/Runtime/master/Schemas/Events/event-horizons.json"
+    },
+    {
+      "name": "Dolittle Resources Configuration",
+      "description": "A JSON schema for a Dolittle bounded context's resource configurations",
+      "fileMatch": ["**/.dolittle/resources.json"],
+      "url": "https://raw.githubusercontent.com/dolittle/DotNET.Fundamentals/v5.1.0/Schemas/ResourceTypes.Configuration/resources.json"
+    },
+    {
+      "name": "Dolittle Server Configuration",
+      "description": "A JSON schema for a Dolittle bounded context's event horizon's interaction server configuration",
+      "fileMatch": ["**/.dolittle/server.json"],
+      "url": "https://raw.githubusercontent.com/dolittle/Runtime/master/Schemas/Server/server.json"
+    },
+    {
+      "name": "Dolittle Tenants Configuration",
+      "description": "A JSON schema for a Dolittle bounded context's tenant configuration",
+      "fileMatch": ["**/.dolittle/tenants.json"],
+      "url": "https://raw.githubusercontent.com/dolittle/Runtime/master/Schemas/Tenancy/tenants.json"
+    },
+    {
+      "name": "Dolittle Tenant Map Configuration",
+      "description": "A JSON schema for a Dolittle bounded context's tenant mapping configurations",
+      "fileMatch": ["**/.dolittle/tenant-map.json"],
+      "url": "https://raw.githubusercontent.com/dolittle/DotNET.Fundamentals/master/Schemas/Tenancy.Configuration/tenant-map.json"
+    },
+    {
+      "name": "Dolittle Topology",
+      "description": "A JSON schema for a Dolittle bounded context's topology",
+      "fileMatch": ["**/.dolittle/topology.json"],
+      "url": "https://raw.githubusercontent.com/dolittle/DotNET.SDK/master/Schemas/Applications.Configuration/topology.json"
+    },
+    {
+      "name": "dotnet Release Index manifest",
+      "description": "JSON schema for .NET product collection manifests",
+      "fileMatch": ["dotnet-release-index.json"],
+      "url": "https://json.schemastore.org/dotnet-releases-index.json"
+    },
+    {
+      "name": "dotnetcli.host.json",
+      "description": "JSON schema for .NET CLI template host files",
+      "fileMatch": ["dotnetcli.host.json"],
+      "url": "https://json.schemastore.org/dotnetcli.host.json"
+    },
+    {
+      "name": "drone.json",
+      "description": "Drone CI configuration file",
+      "fileMatch": [".drone.yml"],
+      "url": "https://json.schemastore.org/drone.json"
+    },
+    {
+      "name": "Drush site aliases",
+      "description": "JSON Schema for Drush 9 site aliases file",
+      "fileMatch": ["**/sites/*.site.yml"],
+      "url": "https://json.schemastore.org/drush.site.yml.json"
+    },
+    {
+      "name": "dss-2.0.0.json",
+      "description": "Digital Signature Service Core Protocols, Elements, and Bindings Version 2.0",
+      "url": "https://json.schemastore.org/dss-2.0.0.json"
+    },
+    {
+      "name": "dstack Workflows",
+      "description": "YAML schema for dstack Workflows",
+      "fileMatch": [
+        "**/.dstack/workflows/*.yml",
+        "**/.dstack/workflows/*.yaml"
+      ],
+      "url": "https://raw.githubusercontent.com/dstackai/dstack/master/cli/dstack/schemas/workflows.json"
+    },
+    {
+      "name": "dvc.yaml",
+      "description": "JSON Schema for dvc.yaml file",
+      "fileMatch": ["dvc.yaml"],
+      "url": "https://raw.githubusercontent.com/iterative/dvcyaml-schema/master/schema.json"
+    },
+    {
+      "name": "Devfile",
+      "description": "JSON schema for Devfiles",
+      "url": "https://raw.githubusercontent.com/devfile/api/v2.2.0/schemas/latest/devfile.json",
+      "fileMatch": ["devfile.yaml", ".devfile.yaml"],
+      "versions": {
+        "1.0.0": "https://raw.githubusercontent.com/eclipse-che/che-server/master/wsmaster/che-core-api-workspace/src/main/resources/schema/1.0.0/devfile.json",
+        "2.0.0": "https://raw.githubusercontent.com/devfile/api/v2.0.0/schemas/latest/devfile.json",
+        "2.1.0": "https://raw.githubusercontent.com/devfile/api/v2.1.0/schemas/latest/devfile.json",
+        "2.2.0": "https://raw.githubusercontent.com/devfile/api/v2.2.0/schemas/latest/devfile.json"
+      }
+    },
+    {
+      "name": "DWP Exchange - gateway",
+      "description": "Schema for exchange publishing tools gateway definitions",
+      "fileMatch": [
+        "**/exchange-config/gateway/prod/*.yaml",
+        "**/exchange-config/gateway/prod/*.yml",
+        "**/exchange-config/gateway/non-prod/*.yaml",
+        "**/exchange-config/gateway/non-prod/*.yml"
+      ],
+      "url": "https://raw.githubusercontent.com/dwp/schemas/main/exchange/publishing-tools/gateway-config-schema.json"
+    },
+    {
+      "name": "DWP Exchange - meta",
+      "description": "Schema for exchange publishing tools meta definition",
+      "fileMatch": [
+        "**/exchange-config/meta.yaml",
+        "**/exchange-config/meta.yml"
+      ],
+      "url": "https://raw.githubusercontent.com/dwp/schemas/main/exchange/publishing-tools/meta-schema.json"
+    },
+    {
+      "name": "DWP Exchange - catalogue entry",
+      "description": "Schema for exchange publishing tools catalogue entry definition",
+      "fileMatch": [
+        "**/exchange-config/portal/catalogue-entry.yaml",
+        "**/exchange-config/portal/catalogue-entry.yml"
+      ],
+      "url": "https://raw.githubusercontent.com/dwp/schemas/main/exchange/publishing-tools/catalogue-entry-schema.json"
+    },
+    {
+      "name": "ecosystem.json",
+      "description": "PM2 ecosystem config file",
+      "fileMatch": [
+        "ecosystem.json",
+        "ecosystem.yml",
+        "ecosystem.yaml",
+        "ecosystem.config.json",
+        "ecosystem.config.yml",
+        "ecosystem.config.yaml"
+      ],
+      "url": "https://json.schemastore.org/pm2-ecosystem.json"
+    },
+    {
+      "name": "eksctl",
+      "description": "eksctl cluster configuration file",
+      "url": "https://raw.githubusercontent.com/weaveworks/eksctl/main/pkg/apis/eksctl.io/v1alpha5/assets/schema.json"
+    },
+    {
+      "name": ".esmrc.json",
+      "description": "Configuration files for the esm module/package in Node.js",
+      "fileMatch": [
+        ".esmrc",
+        ".esmrc.json",
+        ".esmrc.js",
+        ".esmrc.cjs",
+        ".esmrc.mjs"
+      ],
+      "url": "https://json.schemastore.org/esmrc.json"
+    },
+    {
+      "name": "Esquio",
+      "description": "JSON schema for Esquio configuration files",
+      "url": "https://json.schemastore.org/esquio.json"
+    },
+    {
+      "name": "epr-manifest.json",
+      "description": "Entry Point Regulation manifest file",
+      "fileMatch": ["epr-manifest.json"],
+      "url": "https://json.schemastore.org/epr-manifest.json"
+    },
+    {
+      "name": "Error pages",
+      "description": "Error-Pages configuration file",
+      "url": "https://cdn.jsdelivr.net/gh/tarampampam/error-pages@latest/schemas/config/1.0.schema.json",
+      "fileMatch": ["error-pages*.yml", "error-pages*.yaml"],
+      "versions": {
+        "1.0": "https://cdn.jsdelivr.net/gh/tarampampam/error-pages@latest/schemas/config/1.0.schema.json"
+      }
+    },
+    {
+      "name": "electron-builder configuration file.",
+      "description": "JSON schema for electron-build configuration file.",
+      "fileMatch": ["electron-builder.json"],
+      "url": "https://json.schemastore.org/electron-builder.json"
+    },
+    {
+      "name": "evcc.yaml",
+      "description": "JSON schema for evcc configuration file.",
+      "fileMatch": ["evcc*.yaml"],
+      "url": "https://raw.githubusercontent.com/andig/evcc/master/schema.json"
+    },
+    {
+      "name": "Expo SDK",
+      "description": "JSON schema for Expo SDK app manifest",
+      "fileMatch": ["app.json"],
+      "url": "https://json.schemastore.org/expo-46.0.0.json",
+      "versions": {
+        "37.0.0": "https://json.schemastore.org/expo-37.0.0.json",
+        "38.0.0": "https://json.schemastore.org/expo-38.0.0.json",
+        "39.0.0": "https://json.schemastore.org/expo-39.0.0.json",
+        "40.0.0": "https://json.schemastore.org/expo-40.0.0.json",
+        "41.0.0": "https://json.schemastore.org/expo-41.0.0.json",
+        "42.0.0": "https://json.schemastore.org/expo-42.0.0.json",
+        "46.0.0": "https://json.schemastore.org/expo-46.0.0.json"
+      }
+    },
+    {
+      "name": "ezd schema",
+      "description": "Schema for ezd task runner.\n\nSee at: https://gitlab.com/sbenv/veroxis/ezd-rs",
+      "fileMatch": ["ezd.yaml", "ezd.json", "ezd.yml"],
+      "url": "https://gitlab.com/sbenv/veroxis/ezd-rs/-/raw/HEAD/ezd.schema.json"
+    },
+    {
+      "name": ".eslintrc",
+      "description": "JSON schema for ESLint configuration files",
+      "fileMatch": [
+        ".eslintrc",
+        ".eslintrc.json",
+        ".eslintrc.yml",
+        ".eslintrc.yaml"
+      ],
+      "url": "https://json.schemastore.org/eslintrc.json"
+    },
+    {
+      "name": "Facets - FSDL - Application",
+      "description": "Facets Stack Definition Language for Applications",
+      "fileMatch": ["**/application/instances/*.json"],
+      "url": "https://www.facets.cloud/assets/fsdl/application.schema.json"
+    },
+    {
+      "name": "fabric.mod.json",
+      "description": "Metadata file used by the Fabric mod loader",
+      "fileMatch": ["fabric.mod.json"],
+      "url": "https://json.schemastore.org/fabric.mod.json"
+    },
+    {
+      "name": "F-Droid Data metadata",
+      "description": "Schema for F-Droid Data app metadata files",
+      "fileMatch": ["**/metadata/*.yml"],
+      "url": "https://gitlab.com/fdroid/fdroiddata/-/raw/master/schemas/metadata.json"
+    },
+    {
+      "name": ".ffizer.yaml",
+      "description": "JSON schema for ffizer template configuration files",
+      "fileMatch": [".ffizer.yaml"],
+      "url": "https://ffizer.github.io/ffizer/ffizer.schema.json"
+    },
+    {
+      "name": "first-timers-bot",
+      "description": "A bot that helps onboarding new open-source contributors.",
+      "fileMatch": ["**/.github/first-timers.yml"],
+      "url": "https://json.schemastore.org/first-timers.json"
+    },
+    {
+      "name": "Foundry VTT - Manifest",
+      "description": "JSON schema for Foundry VTT system.json and module.json files.",
+      "fileMatch": ["system.json", "module.json"],
+      "url": "https://json.schemastore.org/foundryvtt-manifest.json"
+    },
+    {
+      "name": "Foundry VTT - Template",
+      "description": "JSON schema for Foundry VTT template.json files.",
+      "fileMatch": ["template.json"],
+      "url": "https://json.schemastore.org/foundryvtt-template.json"
+    },
+    {
+      "name": "Fossa configuration file",
+      "description": "JSON schema for FOSSA CLI's .fossa.yml configuration file",
+      "fileMatch": [".fossa.yml"],
+      "url": "https://raw.githubusercontent.com/fossas/fossa-cli/master/docs/references/files/fossa-yml.v3.schema.json"
+    },
+    {
+      "name": "Fossa's fossa-deps file",
+      "description": "JSON schema for FOSSA CLI's fossa-deps file",
+      "fileMatch": ["fossa-deps.yml", "fossa-deps.yaml", "fossa-deps.json"],
+      "url": "https://raw.githubusercontent.com/fossas/fossa-cli/master/docs/references/files/fossa-deps.schema.json"
+    },
+    {
+      "name": "Knative Functions - func.yaml",
+      "description": "JSON schema for Knative Functions func.yaml files",
+      "fileMatch": ["func.yaml"],
+      "url": "https://raw.githubusercontent.com/knative/func/latest-release/schema/func_yaml-schema.json",
+      "versions": {
+        "1.7": "https://raw.githubusercontent.com/knative/func/release-1.7/schema/func_yaml-schema.json",
+        "1.8": "https://raw.githubusercontent.com/knative/func/release-1.8/schema/func_yaml-schema.json"
+      }
+    },
+    {
+      "name": "function.json",
+      "description": "JSON schema for Azure Functions function.json files",
+      "fileMatch": ["function.json"],
+      "url": "https://json.schemastore.org/function.json"
+    },
+    {
+      "name": "GatewayCore API Gateway",
+      "description": "JSON schema for Cloudtoid GatewayCore API Gateway and Reverse Proxy",
+      "fileMatch": [
+        "gwcore.json",
+        "gwcore.yml",
+        "gwcore.yaml",
+        "gatewaycore.json",
+        "gatewaycore.yml",
+        "gatewaycore.yaml",
+        "*.gwcore.json",
+        "*.gwcore.yml",
+        "*.gwcore.yaml",
+        "*.gatewaycore.json",
+        "*.gatewaycore.yml",
+        "*.gatewaycore.yaml"
+      ],
+      "url": "https://raw.githubusercontent.com/cloudtoid/gateway-core/master/src/Cloudtoid.GatewayCore/Options/Schema/2021-07.json",
+      "versions": {
+        "latest": "https://raw.githubusercontent.com/cloudtoid/gateway-core/master/src/Cloudtoid.GatewayCore/Options/Schema/2021-07.json",
+        "2021-07": "https://raw.githubusercontent.com/cloudtoid/gateway-core/master/src/Cloudtoid.GatewayCore/Options/Schema/2021-07.json"
+      }
+    },
+    {
+      "name": "Global Privacy Control",
+      "description": "Configuration for GPC, so a site can convey its support for the Global Privacy Control.",
+      "fileMatch": ["**/.well-known/gpc.json"],
+      "url": "https://json.schemastore.org/gpc.json"
+    },
+    {
+      "name": "geojson.json",
+      "description": "GeoJSON format for representing geographic data.",
+      "url": "https://json.schemastore.org/geojson.json"
+    },
+    {
+      "name": "GitVersion",
+      "description": "The output from the GitVersion tool",
+      "fileMatch": ["gitversion.json"],
+      "url": "https://json.schemastore.org/gitversion.json"
+    },
+    {
+      "name": "GitHub Action",
+      "description": "YAML schema for GitHub Actions",
+      "fileMatch": ["action.yml", "action.yaml"],
+      "url": "https://json.schemastore.org/github-action.json"
+    },
+    {
+      "name": "GitHub Funding",
+      "description": "YAML schema for GitHub Funding",
+      "fileMatch": [
+        "**/.github/FUNDING.yml",
+        "**/.github/funding.yml",
+        "**/.github/funding.yaml"
+      ],
+      "url": "https://json.schemastore.org/github-funding.json"
+    },
+    {
+      "name": "GitHub issue forms",
+      "description": "YAML schema for GitHub issue forms",
+      "fileMatch": [
+        "**/.github/ISSUE_TEMPLATE/**.yml",
+        "**/.github/ISSUE_TEMPLATE/**.yaml"
+      ],
+      "url": "https://json.schemastore.org/github-issue-forms.json"
+    },
+    {
+      "name": "GitHub Issue Template configuration",
+      "description": "YAML schema for configuring GitHub Issue Templates",
+      "fileMatch": [
+        "**/.github/ISSUE_TEMPLATE/config.yml",
+        "**/.github/ISSUE_TEMPLATE/config.yaml"
+      ],
+      "url": "https://json.schemastore.org/github-issue-config.json"
+    },
+    {
+      "name": "GitHub Workflow",
+      "description": "YAML schema for GitHub Workflow",
+      "fileMatch": [
+        "**/.github/workflows/*.yml",
+        "**/.github/workflows/*.yaml"
+      ],
+      "url": "https://json.schemastore.org/github-workflow.json"
+    },
+    {
+      "name": "GitHub Workflow Template Properties",
+      "description": "Json schema for properties json file for a GitHub Workflow template",
+      "fileMatch": ["**/.github/workflow-templates/**.properties.json"],
+      "url": "https://json.schemastore.org/github-workflow-template-properties.json"
+    },
+    {
+      "name": "gitlab-ci",
+      "description": "JSON schema for configuring Gitlab CI",
+      "fileMatch": ["*.gitlab-ci.yml"],
+      "url": "https://gitlab.com/gitlab-org/gitlab/-/raw/master/app/assets/javascripts/editor/schema/ci.json"
+    },
+    {
+      "name": "Gitpod Configuration",
+      "description": "JSON schema for configuring Gitpod.io",
+      "fileMatch": [".gitpod.yml"],
+      "url": "https://gitpod.io/schemas/gitpod-schema.json"
+    },
+    {
+      "name": "global.json",
+      "description": "ASP.NET global configuration file",
+      "fileMatch": ["global.json"],
+      "url": "https://json.schemastore.org/global.json"
+    },
+    {
+      "name": "golangci-lint Configuration",
+      "description": "golangci-lint configuration file",
+      "fileMatch": [
+        ".golangci.yml",
+        ".golangci.yaml",
+        ".golangci.toml",
+        ".golangci.json"
+      ],
+      "url": "https://json.schemastore.org/golangci-lint.json"
+    },
+    {
+      "name": "Goreleaser",
+      "description": "Goreleaser configuration file",
+      "fileMatch": [
+        ".goreleaser.yml",
+        ".goreleaser.yaml",
+        "goreleaser.yml",
+        "goreleaser.yaml"
+      ],
+      "url": "https://goreleaser.com/static/schema.json"
+    },
+    {
+      "name": "Goreleaser Pro",
+      "description": "Goreleaser Pro configuration file",
+      "url": "https://goreleaser.com/static/schema-pro.json"
+    },
+    {
+      "name": "Grafana 5.x Dashboard",
+      "description": "JSON Schema for Grafana 5.x Dashboards",
+      "url": "https://json.schemastore.org/grafana-dashboard-5.x.json"
+    },
+    {
+      "name": "GraphQL Mesh",
+      "description": "JSON Schema for GraphQL Mesh config file",
+      "url": "https://unpkg.com/@graphql-mesh/types/esm/config-schema.json",
+      "fileMatch": [
+        ".meshrc.yml",
+        ".meshrc.yaml",
+        ".meshrc.json",
+        ".meshrc.js",
+        ".graphql-mesh.yaml",
+        ".graphql-mesh.yml"
+      ]
+    },
+    {
+      "name": "GraphQL Config",
+      "description": "JSON Schema for GraphQL Config config file",
+      "url": "https://unpkg.com/graphql-config/config-schema.json",
+      "fileMatch": [
+        "graphql.config.json",
+        "graphql.config.js",
+        "graphql.config.yaml",
+        "graphql.config.yml",
+        ".graphqlrc",
+        ".graphqlrc.json",
+        ".graphqlrc.yaml",
+        ".graphqlrc.yml",
+        ".graphqlrc.js"
+      ]
+    },
+    {
+      "name": "GraphQL Code Generator",
+      "description": "JSON Schema for GraphQL Code Generator config file",
+      "url": "https://www.graphql-code-generator.com/config.schema.json",
+      "fileMatch": [
+        "codegen.yml",
+        "codegen.yaml",
+        "codegen.json",
+        "codegen.js",
+        ".codegen.yml",
+        ".codegen.yaml",
+        ".codegen.json",
+        ".codegen.js"
+      ]
+    },
+    {
+      "name": "Grunt copy task",
+      "description": "Grunt copy task configuration file",
+      "fileMatch": ["copy.json"],
+      "url": "https://json.schemastore.org/grunt-copy-task.json"
+    },
+    {
+      "name": "Grunt clean task",
+      "description": "Grunt clean task configuration file",
+      "fileMatch": ["clean.json"],
+      "url": "https://json.schemastore.org/grunt-clean-task.json"
+    },
+    {
+      "name": "Grunt cssmin task",
+      "description": "Grunt cssmin task configuration file",
+      "fileMatch": ["cssmin.json"],
+      "url": "https://json.schemastore.org/grunt-cssmin-task.json"
+    },
+    {
+      "name": "Grunt JSHint task",
+      "description": "Grunt JSHint task configuration file",
+      "fileMatch": ["jshint.json"],
+      "url": "https://json.schemastore.org/grunt-jshint-task.json"
+    },
+    {
+      "name": "Grunt Watch task",
+      "description": "Grunt Watch task configuration file",
+      "fileMatch": ["watch.json"],
+      "url": "https://json.schemastore.org/grunt-watch-task.json"
+    },
+    {
+      "name": "Grunt base task",
+      "description": "Schema for standard Grunt tasks",
+      "fileMatch": ["**/grunt/*.json", "*-tasks.json"],
+      "url": "https://json.schemastore.org/grunt-task.json"
+    },
+    {
+      "name": "haxelib.json",
+      "description": "Haxelib manifest",
+      "fileMatch": ["haxelib.json"],
+      "url": "https://raw.githubusercontent.com/HaxeFoundation/haxelib/master/schema.json"
+    },
+    {
+      "name": "Hayson",
+      "description": "Project Haystack data",
+      "fileMatch": ["*.hayson.json", "*.hayson.yaml", "*.hayson.yml"],
+      "url": "https://raw.githubusercontent.com/j2inn/hayson/master/hayson-json-schema.json"
+    },
+    {
+      "name": "Haystack Pipeline",
+      "description": "Haystack Pipeline YAML file describing the nodes of the pipelines. For more info read the docs at: https://haystack.deepset.ai/components/pipelines#yaml-file-definitions",
+      "fileMatch": ["*.haystack-pipeline.yml"],
+      "url": "https://raw.githubusercontent.com/deepset-ai/haystack-json-schema/main/json-schema/haystack-pipeline.schema.json"
+    },
+    {
+      "name": "Hazelcast 5 Configuration",
+      "description": "YAML schema for configuring Hazelcast 5 Platform (member and client)",
+      "fileMatch": [
+        "hazelcast*.yaml",
+        "hazelcast*.json",
+        "hz-*.yaml",
+        "hz-*.json"
+      ],
+      "url": "https://hazelcast.com/schema/config/hazelcast-config-5.2.json"
+    },
+    {
+      "name": "host.json",
+      "description": "JSON schema for Azure Functions host.json files",
+      "fileMatch": ["host.json"],
+      "url": "https://json.schemastore.org/host.json"
+    },
+    {
+      "name": "host-meta.json",
+      "description": "Schema for host-meta JDR files",
+      "fileMatch": ["host-meta.json"],
+      "url": "https://json.schemastore.org/host-meta.json"
+    },
+    {
+      "name": ".htmlhintrc",
+      "description": "HTML Hint configuration file",
+      "fileMatch": [".htmlhintrc"],
+      "url": "https://json.schemastore.org/htmlhint.json"
+    },
+    {
+      "name": "Ory Hydra configuration",
+      "description": "Schema for Ory Hydra configuration file",
+      "fileMatch": ["hydra.json", "hydra.yml", "hydra.yaml", "hydra.toml"],
+      "url": "https://raw.githubusercontent.com/ory/hydra/master/.schema/version.schema.json"
+    },
+    {
+      "name": "ide.host.json",
+      "description": "JSON schema for IDE template host file",
+      "fileMatch": ["ide.host.json"],
+      "url": "https://json.schemastore.org/ide.host.json"
+    },
+    {
+      "name": "imageoptimizer.json",
+      "description": "Schema for imageoptimizer.json files",
+      "fileMatch": ["imageoptimizer.json"],
+      "url": "https://json.schemastore.org/imageoptimizer.json"
+    },
+    {
+      "name": ".imgbotconfig",
+      "description": "Imgbot Configuration Files",
+      "fileMatch": [".imgbotconfig"],
+      "url": "https://json.schemastore.org/imgbotconfig.json"
+    },
+    {
+      "name": "importmap.json",
+      "description": "JSON schema for Import Maps files",
+      "fileMatch": ["importmap.json", "import_map.json", "import-map.json"],
+      "url": "https://json.schemastore.org/importmap.json"
+    },
+    {
+      "name": "ioBroker JSON UI",
+      "description": "Schema for ioBroker JSON-based admin user interfaces - config, custom and tabs",
+      "fileMatch": ["jsonConfig.json", "jsonCustom.json", "jsonTab.json"],
+      "url": "https://raw.githubusercontent.com/ioBroker/adapter-react-v5/main/schemas/jsonConfig.json"
+    },
+    {
+      "name": "ioBroker Package manifest",
+      "description": "Schema for ioBroker adapters io-package file",
+      "fileMatch": ["io-package.json"],
+      "url": "https://raw.githubusercontent.com/ioBroker/ioBroker.js-controller/master/schemas/io-package.json"
+    },
+    {
+      "name": "Jasmine",
+      "description": "Schema for jasmine JSON config file",
+      "fileMatch": ["jasmine.json"],
+      "url": "https://json.schemastore.org/jasmine.json"
+    },
+    {
+      "name": "Jekyll",
+      "description": "Jekyll static site generator config file schema",
+      "fileMatch": ["_config.yml"],
+      "url": "https://json.schemastore.org/jekyll.json"
+    },
+    {
+      "name": "Jenkins X Pipelines",
+      "description": "Jenkins X Pipeline YAML configuration files",
+      "fileMatch": ["jenkins-x*.yml"],
+      "url": "https://jenkins-x.io/schemas/jx-schema.json"
+    },
+    {
+      "name": "Jenkins X Requirements",
+      "description": "Jenkins X Requirements YAML configuration file",
+      "fileMatch": ["jx-requirements.yml"],
+      "url": "https://jenkins-x.io/schemas/jx-requirements.json"
+    },
+    {
+      "name": "JDownloader2 crawler single-rule schema",
+      "description": "A schema for validating a single jdownloader2 rule",
+      "fileMatch": ["*.jd2cr", "*.jd2cr.json"],
+      "url": "https://raw.githubusercontent.com/sergxerj/jdownloader2-crawler-rule-json-schema/main/jd2cr.schema.json"
+    },
+    {
+      "name": "JDownloader2 crawler multi-rule schema",
+      "description": "A schema for validating an array of jdownloader2 rules.",
+      "fileMatch": ["*.jd2mcr", "*.jd2mcr.json", "*.linkcrawlerrules.json"],
+      "url": "https://raw.githubusercontent.com/sergxerj/jdownloader2-crawler-rule-json-schema/main/jd2mcr.schema.json"
+    },
+    {
+      "name": "JFrog File Spec",
+      "description": "JFrog File Spec schema definition",
+      "fileMatch": ["**/filespecs/*.json", "*filespec*.json", "*.filespec"],
+      "url": "https://raw.githubusercontent.com/jfrog/jfrog-cli/v2/schema/filespec-schema.json"
+    },
+    {
+      "name": "Jovo Language Models",
+      "description": "JSON Schema for Jovo language Models (https://www.jovo.tech/docs/model)",
+      "url": "https://json.schemastore.org/jovo-language-model.json"
+    },
+    {
+      "name": ".jsbeautifyrc",
+      "description": "js-beautify configuration file",
+      "fileMatch": [".jsbeautifyrc"],
+      "url": "https://json.schemastore.org/jsbeautifyrc.json"
+    },
+    {
+      "name": ".jsbeautifyrc-nested",
+      "description": "js-beautify configuration file allowing nested `js`, `css`, and `html` attributes",
+      "fileMatch": [".jsbeautifyrc"],
+      "url": "https://json.schemastore.org/jsbeautifyrc-nested.json"
+    },
+    {
+      "name": ".jscsrc",
+      "description": "JSCS configuration file",
+      "fileMatch": [".jscsrc", "jscsrc.json"],
+      "url": "https://json.schemastore.org/jscsrc.json"
+    },
+    {
+      "name": ".jshintrc",
+      "description": "JSHint configuration file",
+      "fileMatch": [".jshintrc"],
+      "url": "https://json.schemastore.org/jshintrc.json"
+    },
+    {
+      "name": ".jsinspectrc",
+      "description": "JSInspect configuration file",
+      "fileMatch": [".jsinspectrc"],
+      "url": "https://json.schemastore.org/jsinspectrc.json"
+    },
+    {
+      "name": "JSON-API",
+      "description": "JSON API document",
+      "url": "https://jsonapi.org/schema"
+    },
+    {
+      "name": "JSON Document Transform",
+      "description": "JSON Document Transform",
+      "url": "https://json.schemastore.org/jdt.json"
+    },
+    {
+      "name": "JSON Feed",
+      "description": "JSON schema for the JSON Feed format",
+      "fileMatch": ["feed.json"],
+      "url": "https://json.schemastore.org/feed.json",
+      "versions": {
+        "1": "https://json.schemastore.org/feed-1.json",
+        "1.1": "https://json.schemastore.org/feed.json"
+      }
+    },
+    {
+      "name": "*.jsonld",
+      "description": "JSON Linked Data files",
+      "fileMatch": ["*.jsonld"],
+      "url": "https://json.schemastore.org/jsonld.json"
+    },
+    {
+      "name": "JSONPatch",
+      "description": "JSONPatch files",
+      "fileMatch": ["*.patch", "*.patch.json"],
+      "url": "https://json.schemastore.org/json-patch.json"
+    },
+    {
+      "name": "jsconfig.json",
+      "description": "JavaScript project configuration file",
+      "fileMatch": ["jsconfig.json"],
+      "url": "https://json.schemastore.org/jsconfig.json"
+    },
+    {
+      "name": "k3d.yaml",
+      "description": "k3d configuration file",
+      "fileMatch": [
+        "k3d.yaml",
+        "k3d.yml",
+        ".k3d.yml",
+        ".k3d.yaml",
+        "*.k3d.yaml",
+        "*.k3d.yml"
+      ],
+      "url": "https://raw.githubusercontent.com/rancher/k3d/main/pkg/config/config.versions.schema.json"
+    },
+    {
+      "name": "KrakenD",
+      "description": "KrakenD API Gateway configuration file",
+      "fileMatch": [
+        "krakend.yaml",
+        "krakend.yml",
+        "krakend.json",
+        "krakend.toml"
+      ],
+      "url": "https://www.krakend.io/schema/v3.json"
+    },
+    {
+      "name": "Datadog Service Definition",
+      "description": "Datadog Service Definition file",
+      "fileMatch": [
+        "service.datadog.yaml",
+        "service.datadog.yml",
+        "service.datadog.json"
+      ],
+      "url": "https://raw.githubusercontent.com/DataDog/schema/main/service-catalog/version.schema.json"
+    },
+    {
+      "name": "Ory Keto configuration",
+      "description": "Schema for Ory Keto configuration file",
+      "fileMatch": ["keto.json", "keto.yml", "keto.yaml", "keto.toml"],
+      "url": "https://raw.githubusercontent.com/ory/keto/master/.schema/version.schema.json"
+    },
+    {
+      "name": "kustomization.yaml",
+      "description": "Kubernetes native configuration management",
+      "fileMatch": ["kustomization.yaml", "kustomization.yml"],
+      "url": "https://json.schemastore.org/kustomization.json"
+    },
+    {
+      "name": "label-commenter-config.yml",
+      "description": "A JSON schema for the configuration of the Label Commenter GitHub Action",
+      "fileMatch": ["**/.github/label-commenter-config.yml"],
+      "url": "https://json.schemastore.org/label-commenter-config.json"
+    },
+    {
+      "name": "launchsettings.json",
+      "description": "A JSON schema for the ASP.NET LaunchSettings.json files",
+      "fileMatch": ["launchsettings.json"],
+      "url": "https://json.schemastore.org/launchsettings.json"
+    },
+    {
+      "name": "lego.json",
+      "description": "Config file for the lego-build CLI tool.",
+      "fileMatch": ["lego.json"],
+      "url": "https://json.schemastore.org/lego.json",
+      "versions": {
+        "1.0": "https://json.schemastore.org/lego.json"
+      }
+    },
+    {
+      "name": "lerna.json",
+      "description": "A JSON schema for lerna.json files",
+      "fileMatch": ["lerna.json"],
+      "url": "https://json.schemastore.org/lerna.json"
+    },
+    {
+      "name": "lgtm.yml",
+      "description": "A JSON schema for lgtm configuration files",
+      "fileMatch": ["lgtm.yml", ".lgtm.yml"],
+      "url": "https://json.schemastore.org/lgtm.json"
+    },
+    {
+      "name": "libman.json",
+      "description": "JSON schema for client-side library config files",
+      "fileMatch": ["libman.json"],
+      "url": "https://json.schemastore.org/libman.json"
+    },
+    {
+      "name": "license-report-config.json",
+      "description": "JSON schema for license report tool configuration file",
+      "fileMatch": ["license-report-config.json"],
+      "url": "https://json.schemastore.org/license-report-config.json"
+    },
+    {
+      "name": "linkinator.config.json",
+      "description": "Linkinator config file",
+      "fileMatch": ["linkinator.config.json"],
+      "url": "https://json.schemastore.org/linkinator-config.json"
+    },
+    {
+      "name": "LinkML Metamodel",
+      "description": "LinkML metamodel file",
+      "fileMatch": [],
+      "url": "https://w3id.org/linkml/meta.schema.json"
+    },
+    {
+      "name": "local.settings.json",
+      "description": "JSON schema for Azure Functions local.settings.json files",
+      "fileMatch": ["local.settings.json"],
+      "url": "https://json.schemastore.org/local.settings.json"
+    },
+    {
+      "name": "localazy.json",
+      "description": "JSON schema for Localazy CLI configuration file. More info at https://localazy.com/docs/cli",
+      "fileMatch": ["localazy.json"],
+      "url": "https://raw.githubusercontent.com/localazy/cli-schema/master/localazy.json"
+    },
+    {
+      "name": "lsdlschema.json",
+      "description": "JSON schema for Linguistic Schema Definition Language files",
+      "fileMatch": ["*.lsdl.yaml", "*.lsdl.json"],
+      "url": "https://json.schemastore.org/lsdlschema.json"
+    },
+    {
+      "name": "A micro editor config schema",
+      "description": "A micro editor config schema",
+      "fileMatch": ["*.settings.json"],
+      "url": "https://json.schemastore.org/micro.json"
+    },
+    {
+      "name": "MegaLinter configuration",
+      "description": "JSON schema for Mega-Linter configuration file (for Mega-Linter users)",
+      "fileMatch": [
+        ".mega-linter.yml",
+        ".megalinter.yml",
+        "*.mega-linter-config.yml",
+        "*.megalinter-config.yml"
+      ],
+      "url": "https://raw.githubusercontent.com/megalinter/megalinter/main/megalinter/descriptors/schemas/megalinter-configuration.jsonschema.json"
+    },
+    {
+      "name": "MegaLinter descriptor",
+      "description": "JSON schema for MegaLinter descriptor files (for MegaLinter contributors)",
+      "fileMatch": ["*.megalinter-descriptor.yml"],
+      "url": "https://raw.githubusercontent.com/megalinter/megalinter/main/megalinter/descriptors/schemas/megalinter-descriptor.jsonschema.json"
+    },
+    {
+      "name": "Meltano project definition",
+      "description": "JSON schema for Meltano project definition files",
+      "fileMatch": ["*meltano.yml"],
+      "url": "https://raw.githubusercontent.com/meltano/meltano/main/schema/meltano.schema.json"
+    },
+    {
+      "name": "Meltano plugin discovery definition",
+      "description": "JSON schema for Meltano plugin discovery definition file",
+      "fileMatch": ["*discovery.yml"],
+      "url": "https://raw.githubusercontent.com/meltano/meltano/main/schema/discovery.schema.json"
+    },
+    {
+      "name": "Microsoft Band Web Tile",
+      "description": "Microsoft Band Web Tile manifest file",
+      "url": "https://json.schemastore.org/band-manifest.json"
+    },
+    {
+      "name": "mimetypes.json",
+      "description": "JSON Schema for mime type collections",
+      "fileMatch": ["mimetypes.json"],
+      "url": "https://json.schemastore.org/mimetypes.json"
+    },
+    {
+      "name": "Minecraft Data Pack Advancement",
+      "description": "Configuration file defining an advancement for a data pack for Minecraft.",
+      "fileMatch": ["**/data/*/advancements/*.json"],
+      "url": "https://json.schemastore.org/minecraft-advancement.json"
+    },
+    {
+      "name": "Minecraft Data Pack Biome",
+      "description": "Configuration file defining a biome for a data pack for Minecraft.",
+      "fileMatch": ["**/data/*/worldgen/biome/*.json"],
+      "url": "https://json.schemastore.org/minecraft-biome.json"
+    },
+    {
+      "name": "Minecraft Data Pack Configured Carver",
+      "description": "Configuration file defining a configured carver for a data pack for Minecraft.",
+      "fileMatch": ["**/data/*/worldgen/configured_carver/*.json"],
+      "url": "https://json.schemastore.org/minecraft-configured-carver.json"
+    },
+    {
+      "name": "Minecraft Data Pack Dimension Type",
+      "description": "Configuration file defining a dimension type for a data pack for Minecraft.",
+      "fileMatch": ["**/data/*/dimension_type/*.json"],
+      "url": "https://json.schemastore.org/minecraft-dimension-type.json"
+    },
+    {
+      "name": "Minecraft Data Pack Dimension",
+      "description": "Configuration file defining a dimension for a data pack for Minecraft.",
+      "fileMatch": ["**/data/*/dimension/*.json"],
+      "url": "https://json.schemastore.org/minecraft-dimension.json"
+    },
+    {
+      "name": "Minecraft Data Pack Item Modifier",
+      "description": "Configuration file defining an item modifier for a data pack for Minecraft.",
+      "fileMatch": ["**/data/*/item_modifiers/*.json"],
+      "url": "https://json.schemastore.org/minecraft-item-modifier.json"
+    },
+    {
+      "name": "Minecraft Data Pack Loot Table",
+      "description": "Configuration file defining a loot table for a data pack for Minecraft.",
+      "fileMatch": ["**/data/*/loot_tables/**/*.json"],
+      "url": "https://json.schemastore.org/minecraft-loot-table.json"
+    },
+    {
+      "name": "Minecraft Data Pack Metadata",
+      "description": "Configuration file defining the metadata of a data pack for Minecraft.",
+      "fileMatch": ["**/pack.mcmeta"],
+      "url": "https://json.schemastore.org/minecraft-pack-mcmeta.json"
+    },
+    {
+      "name": "Minecraft Data Pack Predicate",
+      "description": "Configuration file defining a predicate for a data pack for Minecraft.",
+      "fileMatch": ["**/data/*/predicates/*.json"],
+      "url": "https://json.schemastore.org/minecraft-predicate.json"
+    },
+    {
+      "name": "Minecraft Data Pack Recipe",
+      "description": "Configuration file defining a recipe for a data pack for Minecraft.",
+      "fileMatch": ["**/data/*/recipes/*.json"],
+      "url": "https://json.schemastore.org/minecraft-recipe.json"
+    },
+    {
+      "name": "Minecraft Data Pack Tag",
+      "description": "Configuration file defining a tag for a data pack for Minecraft.",
+      "fileMatch": ["**/data/*/tags/**/*.json"],
+      "url": "https://json.schemastore.org/minecraft-tag.json"
+    },
+    {
+      "name": "Minecraft Data Pack Template Pool",
+      "description": "Configuration file defining a template pool for a data pack for Minecraft.",
+      "fileMatch": ["**/data/*/worldgen/template_pool/*.json"],
+      "url": "https://json.schemastore.org/minecraft-template-pool.json"
+    },
+    {
+      "name": "Minecraft Resourcepack Sounds",
+      "description": "Configuration file defining what sounds play when sound event is triggered for a resourcepack for Minecraft.",
+      "fileMatch": ["**/assets/*/sounds.json"],
+      "url": "https://raw.githubusercontent.com/AxoCode/json-schema/master/minecraft/sounds.json"
+    },
+    {
+      "name": ".mocharc",
+      "description": "JSON schema for MochaJS configuration files",
+      "fileMatch": [
+        ".mocharc.json",
+        ".mocharc.jsonc",
+        ".mocharc.yml",
+        ".mocharc.yaml"
+      ],
+      "url": "https://json.schemastore.org/mocharc.json"
+    },
+    {
+      "name": ".modernizrrc",
+      "description": "Webpack modernizr-loader configuration file",
+      "fileMatch": [".modernizrrc"],
+      "url": "https://json.schemastore.org/modernizrrc.json"
+    },
+    {
+      "name": "mycode.json",
+      "description": "JSON schema for mycode.js files",
+      "fileMatch": ["mycode.json"],
+      "url": "https://json.schemastore.org/mycode.json"
+    },
+    {
+      "name": "napari plugin manifest",
+      "description": "Schema for a napari plugin manifest",
+      "fileMatch": ["napari.yml", "napari.yaml", ".napari.yml", ".napari.yaml"],
+      "url": "https://github.com/napari/npe2/releases/latest/download/schema.json"
+    },
+    {
+      "name": "Netlify config schema",
+      "description": "This schema describes the YAML config that Netlify uses",
+      "fileMatch": ["**/admin/config*.yml"],
+      "url": "https://json.schemastore.org/netlify.json"
+    },
+    {
+      "name": "Nightwatch.js",
+      "description": "nightwatch.js schema",
+      "fileMatch": ["nightwatch.json"],
+      "url": "https://json.schemastore.org/nightwatch.json"
+    },
+    {
+      "name": "ninjs (News in JSON) 2.0",
+      "description": "A JSON Schema for ninjs by the IPTC. News and publishing information. See https://iptc.org/standards/ninjs/",
+      "url": "https://json.schemastore.org/ninjs-2.0.json",
+      "versions": {
+        "2.0": "https://json.schemastore.org/ninjs-2.0.json"
+      }
+    },
+    {
+      "name": "ninjs (News in JSON) 1.3",
+      "description": "A JSON Schema for ninjs by the IPTC. News and publishing information. See https://iptc.org/standards/ninjs/",
+      "url": "https://json.schemastore.org/ninjs-1.3.json",
+      "versions": {
+        "1.3": "https://json.schemastore.org/ninjs-1.3.json",
+        "1.2": "https://json.schemastore.org/ninjs-1.2.json",
+        "1.1": "https://json.schemastore.org/ninjs-1.1.json",
+        "1.0": "https://json.schemastore.org/ninjs-1.0.json"
+      }
+    },
+    {
+      "name": "nest-cli",
+      "description": "A progressive Node.js framework for building efficient and scalable server-side applications 🚀.",
+      "url": "https://json.schemastore.org/nest-cli.json",
+      "fileMatch": [
+        ".nestcli.json",
+        ".nest-cli.json",
+        "nest-cli.json",
+        "nest.json"
+      ]
+    },
+    {
+      "name": "nlu.json",
+      "description": "Schema for NPM-Link-Up",
+      "fileMatch": ["nlu.json", ".nlu.json"],
+      "url": "https://raw.githubusercontent.com/oresoftware/npm-link-up/master/assets/nlu.schema.json"
+    },
+    {
+      "name": ".nodehawkrc",
+      "description": "JSON schema for .nodehawkrc configuration files.",
+      "url": "https://json.schemastore.org/nodehawkrc.json",
+      "fileMatch": [".nodehawkrc"]
+    },
+    {
+      "name": "nodemon.json",
+      "description": "JSON schema for nodemon.json configuration files.",
+      "url": "https://json.schemastore.org/nodemon.json",
+      "fileMatch": ["nodemon.json"]
+    },
+    {
+      "name": "NOX Framework (Service)",
+      "description": "Schema for NOX service definition",
+      "url": "https://noxorg.dev/schemas/NoxConfiguration.json",
+      "fileMatch": ["service.nox.yaml", "service.nox.yml", "service.nox.json"]
+    },
+    {
+      "name": ".npmpackagejsonlintrc",
+      "description": "Configuration file for npm-package-json-lint",
+      "fileMatch": [
+        ".npmpackagejsonlintrc",
+        "npmpackagejsonlintrc.json",
+        ".npmpackagejsonlintrc.json"
+      ],
+      "url": "https://json.schemastore.org/npmpackagejsonlintrc.json"
+    },
+    {
+      "name": "npm-badges",
+      "description": "JSON schema for the NPM package badges.",
+      "url": "https://json.schemastore.org/npm-badges.json"
+    },
+    {
+      "name": "nuclei-template.yaml",
+      "description": "JSON schema for Nuclei Template YAML files.",
+      "url": "https://raw.githubusercontent.com/projectdiscovery/nuclei/master/nuclei-jsonschema.json",
+      "fileMatch": ["**/nuclei-templates/**/*.yaml"]
+    },
+    {
+      "name": "nuget-project.json",
+      "description": "JSON schema for NuGet project.json files.",
+      "url": "https://json.schemastore.org/nuget-project.json",
+      "versions": {
+        "3.3.0": "https://json.schemastore.org/nuget-project-3.3.0.json"
+      }
+    },
+    {
+      "name": "nswag.json",
+      "description": "JSON schema for nswag configuration",
+      "url": "https://json.schemastore.org/nswag.json",
+      "fileMatch": ["nswag.json"]
+    },
+    {
+      "name": "ntangle",
+      "description": "NTangle (https://github.com/Avanade/ntangle) CDC code-generation configuration.",
+      "url": "https://raw.githubusercontent.com/Avanade/NTangle/main/schemas/ntangle.json",
+      "fileMatch": [
+        "ntangle.yaml",
+        "ntangle.yml",
+        "ntangle.json",
+        "ntangle.jsn"
+      ]
+    },
+    {
+      "name": "Ory Oathkeeper configuration",
+      "description": "Schema for Ory Oathkeeper configuration file",
+      "fileMatch": [
+        "oathkeeper.json",
+        "oathkeeper.yml",
+        "oathkeeper.yaml",
+        "oathkeeper.toml"
+      ],
+      "url": "https://raw.githubusercontent.com/ory/oathkeeper/master/.schema/version.schema.json"
+    },
+    {
+      "name": "ocelot.json",
+      "description": "JSON schema for the Ocelot Api Gateway.",
+      "fileMatch": ["ocelot.json"],
+      "url": "https://json.schemastore.org/ocelot.json"
+    },
+    {
+      "name": "omnisharp.json",
+      "description": "Omnisharp Configuration file",
+      "fileMatch": ["omnisharp.json"],
+      "url": "https://json.schemastore.org/omnisharp.json"
+    },
+    {
+      "name": "openapi.json",
+      "description": "A JSON schema for Open API documentation files",
+      "fileMatch": ["openapi.json", "openapi.yml", "openapi.yaml"],
+      "url": "https://raw.githubusercontent.com/OAI/OpenAPI-Specification/main/schemas/v3.1/schema.json",
+      "versions": {
+        "3.0": "https://raw.githubusercontent.com/OAI/OpenAPI-Specification/main/schemas/v3.0/schema.json",
+        "3.1": "https://raw.githubusercontent.com/OAI/OpenAPI-Specification/main/schemas/v3.1/schema.json"
+      }
+    },
+    {
+      "name": "openrpc.json",
+      "description": "A JSON schema for OpenRPC documents. See https://open-rpc.org for more information.",
+      "fileMatch": [
+        "openrpc.json",
+        "openrpc.yml",
+        "openrpc.yaml",
+        "open-rpc.json",
+        "open-rpc.yml",
+        "open-rpc.yaml"
+      ],
+      "url": "https://meta.open-rpc.org/"
+    },
+    {
+      "name": "openfin.json",
+      "description": "OpenFin application configuration file",
+      "url": "https://json.schemastore.org/openfin.json"
+    },
+    {
+      "name": "Outblocks project configuration",
+      "description": "JSON schema for Outblocks project configuration files",
+      "fileMatch": ["project.outblocks.yaml", "project.outblocks.yml"],
+      "url": "https://raw.githubusercontent.com/outblocks/outblocks-cli/master/schema/schema-project.json"
+    },
+    {
+      "name": "Outblocks App configuration",
+      "description": "JSON schema for Outblocks App configuration files",
+      "fileMatch": [
+        "app.outblocks.yaml",
+        "app.outblocks.yml",
+        "*.app.outblocks.yaml",
+        "*.app.outblocks.yml",
+        "outblocks.yaml",
+        "outblocks.yml"
+      ],
+      "url": "https://raw.githubusercontent.com/outblocks/outblocks-cli/master/schema/schema-app.json"
+    },
+    {
+      "name": "Outblocks database table",
+      "description": "JSON schema for Outblocks database table files",
+      "fileMatch": [
+        "**/database/**/*.outblocks.yaml",
+        "**/database/**/*.outblocks.yml"
+      ],
+      "url": "https://raw.githubusercontent.com/outblocks/outblocks-cli/master/schema/schema-table.json"
+    },
+    {
+      "name": "Ory Kratos configuration",
+      "description": "Schema for Ory Kratos configuration file",
+      "fileMatch": ["kratos.json", "kratos.yml", "kratos.yaml", "kratos.toml"],
+      "url": "https://raw.githubusercontent.com/ory/kratos/master/.schema/version.schema.json"
+    },
+    {
+      "name": "OSS Review Toolkit configuration",
+      "description": "Schema for ORT's main configuration file",
+      "fileMatch": ["**/.ort/config/config.yml", "**/.ort/config/config.yaml"],
+      "url": "https://raw.githubusercontent.com/oss-review-toolkit/ort/main/integrations/schemas/ort-configuration-schema.json"
+    },
+    {
+      "name": "OSS Review Toolkit curation",
+      "description": "Schema for ORT's curation files",
+      "fileMatch": [
+        "**/curations/**/*.yml",
+        "**/curations/**/*.yaml",
+        "curations.yml",
+        "curations.yaml"
+      ],
+      "url": "https://raw.githubusercontent.com/oss-review-toolkit/ort/main/integrations/schemas/curations-schema.json"
+    },
+    {
+      "name": "OSS Review Toolkit package configuration",
+      "description": "Schema for ORT's package configuration file",
+      "fileMatch": [
+        "vcs.yml",
+        "vcs.yaml",
+        "source-artifact.yml",
+        "source-artifact.yaml"
+      ],
+      "url": "https://raw.githubusercontent.com/oss-review-toolkit/ort/main/integrations/schemas/package-configuration-schema.json"
+    },
+    {
+      "name": "OSS Review Toolkit repository configuration",
+      "description": "Schema for ORT's repository configuration file",
+      "fileMatch": ["*.ort.yml", "*.ort.yaml"],
+      "url": "https://raw.githubusercontent.com/oss-review-toolkit/ort/main/integrations/schemas/repository-configuration-schema.json"
+    },
+    {
+      "name": "OSS Review Toolkit resolutions",
+      "description": "Schema for ORT's resolutions file",
+      "fileMatch": ["resolutions.yml", "resolutions.yaml"],
+      "url": "https://raw.githubusercontent.com/oss-review-toolkit/ort/main/integrations/schemas/resolutions-schema.json"
+    },
+    {
+      "name": "package.json",
+      "description": "NPM configuration file",
+      "fileMatch": ["package.json"],
+      "url": "https://json.schemastore.org/package.json"
+    },
+    {
+      "name": "package.manifest",
+      "description": "Umbraco package configuration file",
+      "fileMatch": ["package.manifest"],
+      "url": "https://json.schemastore.org/package.manifest.json",
+      "versions": {
+        "8.0.0": "https://json.schemastore.org/package.manifest-8.0.0.json",
+        "7.0.0": "https://json.schemastore.org/package.manifest-7.0.0.json"
+      }
+    },
+    {
+      "name": "Packer",
+      "description": "Packer template JSON configuration",
+      "fileMatch": ["packer.json"],
+      "url": "https://json.schemastore.org/packer.json"
+    },
+    {
+      "name": "pgap_yaml_input_reader",
+      "description": "NCBI Prokaryotic Genome Annotation Pipeline (PGAP) input metadata (submol) JSON/YAML configuration file",
+      "fileMatch": ["submol*.json", "submol*.yml", "submol*.yaml"],
+      "url": "https://json.schemastore.org/pgap_yaml_input_reader.json"
+    },
+    {
+      "name": "pattern.json",
+      "description": "Patternplate pattern manifest file",
+      "fileMatch": ["pattern.json"],
+      "url": "https://json.schemastore.org/pattern.json"
+    },
+    {
+      "name": ".pmbot.yml",
+      "description": "Pmbot configuration file",
+      "fileMatch": [".pmbot.yml"],
+      "url": "https://raw.githubusercontent.com/pmbot-io/config/master/pmbot.yml.schema.json"
+    },
+    {
+      "name": "PocketMine plugin.yml",
+      "description": "PocketMine plugin manifest file",
+      "fileMatch": ["plugin.yml"],
+      "url": "https://json.schemastore.org/pocketmine-plugin.json"
+    },
+    {
+      "name": "plagiarize.yaml",
+      "description": "Yaml schema for Plagiarize",
+      "fileMatch": ["plagiarize.yaml", "plagiarize.json"],
+      "versions": {
+        "0.0": "https://json.schemastore.org/plagiarize-0.0.json"
+      },
+      "url": "https://json.schemastore.org/plagiarize.json"
+    },
+    {
+      "name": "plagiarize-me.yaml",
+      "description": "Yaml schema for Plagiarize MEe",
+      "fileMatch": ["plagiarize-me.yaml", "plagiarize-me.json"],
+      "versions": {
+        "0.0": "https://json.schemastore.org/plagiarize-me-0.0.json"
+      },
+      "url": "https://json.schemastore.org/plagiarize-me.json"
+    },
+    {
+      "name": "portman.json",
+      "description": "JSON schema for Portman's configuration file",
+      "fileMatch": ["portman-config.json", "portman.json"],
+      "url": "https://raw.githubusercontent.com/apideck-libraries/portman/main/src/utils/portman-config-schema.json"
+    },
+    {
+      "name": ".postcssrc",
+      "description": "PostCSS configuration file",
+      "fileMatch": [
+        ".postcssrc",
+        ".postcssrc.json",
+        ".postcssrc.yaml",
+        ".postcssrc.yml"
+      ],
+      "url": "https://json.schemastore.org/postcssrc.json"
+    },
+    {
+      "name": ".pre-commit-config.yml",
+      "description": "pre-commit configuration file",
+      "fileMatch": [".pre-commit-config.yml", ".pre-commit-config.yaml"],
+      "url": "https://json.schemastore.org/pre-commit-config.json"
+    },
+    {
+      "name": ".pre-commit-hooks.yml",
+      "description": "pre-commit hooks definition file",
+      "fileMatch": [".pre-commit-hooks.yml", ".pre-commit-hooks.yaml"],
+      "url": "https://json.schemastore.org/pre-commit-hooks.json"
+    },
+    {
+      "name": ".phraseapp.yml",
+      "description": "PhraseApp configuration file",
+      "fileMatch": [".phraseapp.yml"],
+      "url": "https://json.schemastore.org/phraseapp.json"
+    },
+    {
+      "name": "prettierrc.json",
+      "description": ".prettierrc configuration file",
+      "fileMatch": [
+        ".prettierrc",
+        ".prettierrc.json",
+        ".prettierrc.yml",
+        ".prettierrc.yaml"
+      ],
+      "url": "https://json.schemastore.org/prettierrc.json",
+      "versions": {
+        "1.8.2": "https://json.schemastore.org/prettierrc-1.8.2.json"
+      }
+    },
+    {
+      "name": "prisma.yml",
+      "description": "prisma.yml service definition file",
+      "fileMatch": ["prisma.yml"],
+      "url": "https://json.schemastore.org/prisma.json"
+    },
+    {
+      "name": "project.json",
+      "description": "ASP.NET vNext project configuration file",
+      "fileMatch": ["project.json"],
+      "url": "https://json.schemastore.org/project.json",
+      "versions": {
+        "1.0.0-beta3": "https://json.schemastore.org/project-1.0.0-beta3.json",
+        "1.0.0-beta4": "https://json.schemastore.org/project-1.0.0-beta4.json",
+        "1.0.0-beta5": "https://json.schemastore.org/project-1.0.0-beta5.json",
+        "1.0.0-beta6": "https://json.schemastore.org/project-1.0.0-beta6.json",
+        "1.0.0-beta8": "https://json.schemastore.org/project-1.0.0-beta8.json",
+        "1.0.0-rc1": "https://json.schemastore.org/project-1.0.0-rc1.json",
+        "1.0.0-rc1-update1": "https://json.schemastore.org/project-1.0.0-rc1.json",
+        "1.0.0-rc2": "https://json.schemastore.org/project-1.0.0-rc2.json"
+      }
+    },
+    {
+      "name": "project-1.0.0-beta3.json",
+      "description": "ASP.NET vNext project configuration file",
+      "url": "https://json.schemastore.org/project-1.0.0-beta3.json"
+    },
+    {
+      "name": "project-1.0.0-beta4.json",
+      "description": "ASP.NET vNext project configuration file",
+      "url": "https://json.schemastore.org/project-1.0.0-beta4.json"
+    },
+    {
+      "name": "project-1.0.0-beta5.json",
+      "description": "ASP.NET vNext project configuration file",
+      "url": "https://json.schemastore.org/project-1.0.0-beta5.json"
+    },
+    {
+      "name": "project-1.0.0-beta6.json",
+      "description": "ASP.NET vNext project configuration file",
+      "url": "https://json.schemastore.org/project-1.0.0-beta6.json"
+    },
+    {
+      "name": "project-1.0.0-beta8.json",
+      "description": "ASP.NET vNext project configuration file",
+      "url": "https://json.schemastore.org/project-1.0.0-beta8.json"
+    },
+    {
+      "name": "project-1.0.0-rc1.json",
+      "description": "ASP.NET vNext project configuration file",
+      "url": "https://json.schemastore.org/project-1.0.0-rc1.json"
+    },
+    {
+      "name": "project-1.0.0-rc2.json",
+      "description": ".NET Core project configuration file",
+      "url": "https://json.schemastore.org/project-1.0.0-rc2.json"
+    },
+    {
+      "name": "prometheus.json",
+      "description": "Prometheus configuration file",
+      "fileMatch": ["prometheus.yml", "prometheus.yaml"],
+      "url": "https://json.schemastore.org/prometheus.json"
+    },
+    {
+      "name": "prometheus.rules.json",
+      "description": "Prometheus rules file",
+      "fileMatch": ["*.rules"],
+      "url": "https://json.schemastore.org/prometheus.rules.json"
+    },
+    {
+      "name": "proxies.json",
+      "description": "JSON schema for Azure Function Proxies proxies.json files",
+      "fileMatch": ["proxies.json"],
+      "url": "https://json.schemastore.org/proxies.json"
+    },
+    {
+      "name": "publiccode.yml",
+      "description": "JSON schema for publiccode.yml",
+      "fileMatch": ["publiccode.yml"],
+      "url": "https://json.schemastore.org/publiccode.json"
+    },
+    {
+      "name": "pubspec.yaml",
+      "description": "Schema for pubspecs, the format used by Dart's dependency manager",
+      "fileMatch": ["pubspec.yaml"],
+      "url": "https://json.schemastore.org/pubspec.json"
+    },
+    {
+      "name": "Pull Request Labeler",
+      "description": "A GitHub Action for automatically labelling pull requests",
+      "fileMatch": ["**/.github/labeler.yml"],
+      "url": "https://json.schemastore.org/pull-request-labeler.json"
+    },
+    {
+      "name": ".putout.json",
+      "description": "JSON schema for 🐊Putout configuration file",
+      "fileMatch": [".putout.json"],
+      "url": "https://json.schemastore.org/putout.json"
+    },
+    {
+      "name": "pyrseas-0.8.json",
+      "description": "Pyrseas database schema versioning for Postgres databases, v0.8",
+      "fileMatch": ["pyrseas-0.8.json"],
+      "url": "https://json.schemastore.org/pyrseas-0.8.json"
+    },
+    {
+      "name": "Read the Docs",
+      "description": "Read the Docs configuration file",
+      "fileMatch": [
+        "readthedocs.yml",
+        "readthedocs.yaml",
+        ".readthedocs.yml",
+        ".readthedocs.yaml"
+      ],
+      "url": "https://raw.githubusercontent.com/readthedocs/readthedocs.org/master/readthedocs/rtd_tests/fixtures/spec/v2/schema.json"
+    },
+    {
+      "name": "Pulumi",
+      "description": "JSON schema for Pulumi project metadata and configuration",
+      "fileMatch": ["Pulumi.yaml", "pulumi.yaml"],
+      "url": "https://json.schemastore.org/pulumi.json"
+    },
+    {
+      "name": "PyProject",
+      "description": "JSON schema for Python project metadata and configuration",
+      "fileMatch": ["pyproject.toml"],
+      "url": "https://json.schemastore.org/pyproject.json"
+    },
+    {
+      "name": "Red-DiscordBot Cog",
+      "description": "Red-DiscordBot Cog metadata file",
+      "fileMatch": ["info.json"],
+      "url": "https://raw.githubusercontent.com/Cog-Creators/Red-DiscordBot/V3/develop/schema/red_cog.schema.json"
+    },
+    {
+      "name": "Red-DiscordBot Cog Repo",
+      "description": "Red-DiscordBot Cog Repo metadata file",
+      "fileMatch": ["info.json"],
+      "url": "https://raw.githubusercontent.com/Cog-Creators/Red-DiscordBot/V3/develop/schema/red_cog_repo.schema.json"
+    },
+    {
+      "name": ".rehyperc",
+      "description": "A rehype configuration file",
+      "fileMatch": [
+        ".rehyperc",
+        ".rehyperc.json",
+        ".rehyperc.yaml",
+        ".rehyperc.yml"
+      ],
+      "url": "https://json.schemastore.org/rehyperc.json"
+    },
+    {
+      "name": ".remarkrc",
+      "description": "A remark configuration file",
+      "fileMatch": [
+        ".remarkrc",
+        ".remarkrc.json",
+        ".remarkrc.yaml",
+        ".remarkrc.yml"
+      ],
+      "url": "https://json.schemastore.org/remarkrc.json"
+    },
+    {
+      "name": "Replit schema",
+      "description": "Schema for replit.com, a cloud IDE and code runner",
+      "fileMatch": ["replit.toml"],
+      "url": "https://json.schemastore.org/replit.json"
+    },
+    {
+      "name": "*.resjson",
+      "description": "Windows App localization file",
+      "fileMatch": ["*.resjson"],
+      "url": "https://json.schemastore.org/resjson.json"
+    },
+    {
+      "name": "Ruff",
+      "description": "JSON schema for Ruff, a fast Python linter",
+      "fileMatch": ["ruff.toml"],
+      "url": "https://json.schemastore.org/ruff.json"
+    },
+    {
+      "name": "Rust Project",
+      "description": "JSON schema for non-Cargo based Rust projects",
+      "fileMatch": ["rust-project.json"],
+      "url": "https://json.schemastore.org/rust-project.json"
+    },
+    {
+      "name": "JSON Resume",
+      "description": "A JSON schema to describe a résumé.",
+      "fileMatch": [
+        "**/resume.json",
+        "**/*.resume.json",
+        "**/resume.yaml",
+        "**/*.resume.yaml",
+        "**/resume.yml",
+        "**/*.resume.yml"
+      ],
+      "url": "https://raw.githubusercontent.com/jsonresume/resume-schema/v1.0.0/schema.json",
+      "versions": {
+        "1.0.0": "https://raw.githubusercontent.com/jsonresume/resume-schema/v1.0.0/schema.json"
+      }
+    },
+    {
+      "name": "Renovate",
+      "description": "Renovate configuration file (https://docs.renovatebot.com/configuration-options/)",
+      "fileMatch": [
+        "renovate.json",
+        "renovate.json5",
+        "**/.github/renovate.json",
+        "**/.github/renovate.json5",
+        "**/.gitlab/renovate.json",
+        "**/.gitlab/renovate.json5",
+        ".renovaterc",
+        ".renovaterc.json"
+      ],
+      "url": "https://docs.renovatebot.com/renovate-schema.json"
+    },
+    {
+      "name": "RoadRunner",
+      "description": "Spiral Roadrunner config file schema",
+      "url": "https://cdn.jsdelivr.net/gh/roadrunner-server/roadrunner@latest/schemas/config/2.0.schema.json",
+      "fileMatch": [".rr*.yml", ".rr*.yaml"],
+      "versions": {
+        "1.0": "https://cdn.jsdelivr.net/gh/roadrunner-server/roadrunner@latest/schemas/config/1.0.schema.json",
+        "2.0": "https://cdn.jsdelivr.net/gh/roadrunner-server/roadrunner@latest/schemas/config/2.0.schema.json"
+      }
+    },
+    {
+      "name": "rustfmt",
+      "description": "Schema for fustfmt, a tool to format Rust code",
+      "fileMatch": ["rustfmt.toml"],
+      "url": "https://json.schemastore.org/rustfmt.json"
+    },
+    {
+      "name": "Rust toolchain",
+      "description": "A declarative schema for managing the Rust toolchain",
+      "fileMatch": ["rust-toolchain.toml"],
+      "url": "https://json.schemastore.org/rust-toolchain.json"
+    },
+    {
+      "name": "Sapphire CLI Config",
+      "description": "Scheme for Sapphire CLI Config (@sapphire/cli)",
+      "fileMatch": [".sapphirerc.json", ".sapphirerc.yml"],
+      "url": "https://raw.githubusercontent.com/sapphiredev/cli/main/templates/schemas/.sapphirerc.scheme.json"
+    },
+    {
+      "name": "sarif-1.0.0.json",
+      "description": "Static Analysis Results Interchange Format (SARIF) version 1",
+      "url": "https://json.schemastore.org/sarif-1.0.0.json"
+    },
+    {
+      "name": "sarif-2.0.0.json",
+      "description": "Static Analysis Results Interchange Format (SARIF) version 2",
+      "url": "https://json.schemastore.org/sarif-2.0.0.json"
+    },
+    {
+      "name": "sarif-2.1.0-rtm.2",
+      "description": "Static Analysis Results Format (SARIF), Version 2.1.0-rtm.2",
+      "url": "https://json.schemastore.org/sarif-2.1.0-rtm.2.json"
+    },
+    {
+      "name": "sarif-external-property-file-2.1.0-rtm.2",
+      "description": "Static Analysis Results Format (SARIF) External Property File Format, Version 2.1.0-rtm.2",
+      "url": "https://json.schemastore.org/sarif-external-property-file-2.1.0-rtm.2.json"
+    },
+    {
+      "name": "sarif-2.1.0-rtm.3",
+      "description": "Static Analysis Results Format (SARIF), Version 2.1.0-rtm.3",
+      "url": "https://json.schemastore.org/sarif-2.1.0-rtm.3.json"
+    },
+    {
+      "name": "sarif-external-property-file-2.1.0-rtm.3",
+      "description": "Static Analysis Results Format (SARIF) External Property File Format, Version 2.1.0-rtm.3",
+      "url": "https://json.schemastore.org/sarif-external-property-file-2.1.0-rtm.3.json"
+    },
+    {
+      "name": "sarif-2.1.0-rtm.4",
+      "description": "Static Analysis Results Format (SARIF), Version 2.1.0-rtm.4",
+      "url": "https://json.schemastore.org/sarif-2.1.0-rtm.4.json"
+    },
+    {
+      "name": "sarif-external-property-file-2.1.0-rtm.4",
+      "description": "Static Analysis Results Format (SARIF) External Property File Format, Version 2.1.0-rtm.4",
+      "url": "https://json.schemastore.org/sarif-external-property-file-2.1.0-rtm.4.json"
+    },
+    {
+      "name": "sarif-2.1.0-rtm.5",
+      "description": "Static Analysis Results Format (SARIF), Version 2.1.0-rtm.5",
+      "url": "https://json.schemastore.org/sarif-2.1.0-rtm.5.json"
+    },
+    {
+      "name": "sarif-external-property-file-2.1.0-rtm.5",
+      "description": "Static Analysis Results Format (SARIF) External Property File Format, Version 2.1.0-rtm.5",
+      "url": "https://json.schemastore.org/sarif-external-property-file-2.1.0-rtm.5.json"
+    },
+    {
+      "name": "sarif-2.1.0",
+      "description": "Static Analysis Results Format (SARIF), Version 2.1.0",
+      "url": "https://json.schemastore.org/sarif-2.1.0.json"
+    },
+    {
+      "name": "sarif-external-property-file-2.1.0",
+      "description": "Static Analysis Results Format (SARIF) External Property File Format, Version 2.1.0",
+      "url": "https://json.schemastore.org/sarif-external-property-file-2.1.0.json"
+    },
+    {
+      "name": "Schema Catalog",
+      "description": "JSON Schema catalog files compatible with SchemaStore.org",
+      "url": "https://json.schemastore.org/schema-catalog.json"
+    },
+    {
+      "name": "schema.org - Action",
+      "description": "JSON Schema for Action as defined by schema.org",
+      "url": "https://json.schemastore.org/schema-org-action.json"
+    },
+    {
+      "name": "schema.org - ContactPoint",
+      "description": "JSON Schema for ContactPoint as defined by schema.org",
+      "url": "https://json.schemastore.org/schema-org-contact-point.json"
+    },
+    {
+      "name": "schema.org - Place",
+      "description": "JSON Schema for Place as defined by schema.org",
+      "url": "https://json.schemastore.org/schema-org-place.json"
+    },
+    {
+      "name": "schema.org - Thing",
+      "description": "JSON Schema for Thing as defined by schema.org",
+      "url": "https://json.schemastore.org/schema-org-thing.json"
+    },
+    {
+      "name": "Scoop manifest",
+      "description": "Scoop bucket app manifest",
+      "fileMatch": ["**/bucket/**.json"],
+      "url": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json"
+    },
+    {
+      "name": "semantic-release",
+      "description": "Configuration for semantic-release",
+      "fileMatch": [
+        ".releaserc",
+        ".releaserc.yaml",
+        ".releaserc.yml",
+        ".releaserc.json"
+      ],
+      "url": "https://json.schemastore.org/semantic-release.json"
+    },
+    {
+      "name": "Semgrep Rule",
+      "description": "Semgrep code scanning patterns and rules",
+      "fileMatch": [
+        "**/.semgrep/**.yaml",
+        "**/.semgrep/**.yml",
+        ".semgrep.yaml",
+        ".semgrep.yml"
+      ],
+      "url": "https://json.schemastore.org/semgrep.json"
+    },
+    {
+      "name": "settings.job",
+      "description": "Azure Webjob settings file",
+      "fileMatch": ["settings.job"],
+      "url": "https://json.schemastore.org/settings.job.json"
+    },
+    {
+      "name": "Settings.paf",
+      "description": "Qualisys Project Automation Framework settings file",
+      "fileMatch": ["settings.paf", "Settings.paf"],
+      "url": "https://raw.githubusercontent.com/qualisys/qualisys-schemas/master/paf-module.schema.json"
+    },
+    {
+      "name": "sfdx-hardis configuration",
+      "description": "Configuration file for sfdx-hardis Salesforce DX plugin",
+      "fileMatch": [
+        ".sfdx-hardis.yml",
+        ".sfdx-hardis.yaml",
+        "**/branches/.sfdx-hardis.*.yml",
+        "**/branches/.sfdx-hardis.*.yaml"
+      ],
+      "url": "https://raw.githubusercontent.com/hardisgroupcom/sfdx-hardis/main/config/sfdx-hardis.jsonschema.json"
+    },
+    {
+      "name": "SIL Kit Participant Configuration",
+      "description": "Configuration file for a Vector SIL Kit Participant",
+      "fileMatch": [
+        "silkit.json",
+        "silkit.yaml",
+        "*.silkit.json",
+        "*.silkit.yaml"
+      ],
+      "url": "https://json.schemastore.org/sil-kit-participant-configuration.json"
+    },
+    {
+      "name": "size-limit configuration",
+      "description": "Configuration file for size-limit",
+      "fileMatch": [".size-limit.json"],
+      "url": "https://json.schemastore.org/size-limit.json"
+    },
+    {
+      "name": "skyuxconfig.json",
+      "description": "SKY UX CLI configuration file",
+      "fileMatch": ["skyuxconfig.json", "skyuxconfig.*.json"],
+      "url": "https://raw.githubusercontent.com/blackbaud/skyux-config/master/skyuxconfig-schema.json"
+    },
+    {
+      "name": "snapcraft",
+      "description": "snapcraft project  (https://snapcraft.io)",
+      "fileMatch": [".snapcraft.yaml", "snapcraft.yaml"],
+      "url": "https://raw.githubusercontent.com/snapcore/snapcraft/master/schema/snapcraft.json"
+    },
+    {
+      "name": "Solidarity",
+      "description": "CLI config for enforcing environment settings",
+      "fileMatch": [".solidarity", ".solidarity.json"],
+      "url": "https://json.schemastore.org/solidaritySchema.json"
+    },
+    {
+      "name": "Solution filters",
+      "description": "File that specifies which MSBuild solution to launch and which projects to load",
+      "fileMatch": ["*.slnf"],
+      "url": "https://json.schemastore.org/solution-filter.json"
+    },
+    {
+      "name": "Source Maps v3",
+      "description": "Source Map files version 3",
+      "fileMatch": ["*.map"],
+      "url": "https://json.schemastore.org/sourcemap-v3.json"
+    },
+    {
+      "name": "SpecIF",
+      "description": "The Specification Integration Facility (SpecIF) integrates partial system models from different methods and tools in a semantic net. See https://specif.de and https://github.com/GfSE.",
+      "url": "https://json.schemastore.org/specif-1.1.json",
+      "fileMatch": ["*.specif", "*.specif.json"],
+      "versions": {
+        "1.0": "https://json.schemastore.org/specif-1.0.json",
+        "1.1": "https://json.schemastore.org/specif-1.1.json"
+      }
+    },
+    {
+      "name": "Sponge Mixin configuration",
+      "description": "Configuration file for SpongePowered's Mixin library",
+      "fileMatch": ["*.mixins.json"],
+      "url": "https://json.schemastore.org/sponge-mixins.json"
+    },
+    {
+      "name": ".sprite files",
+      "description": "Schema for image sprite generation files",
+      "fileMatch": ["*.sprite"],
+      "url": "https://json.schemastore.org/sprite.json"
+    },
+    {
+      "name": "Azure Static Web Apps configuration file",
+      "description": "Documentation: https://aka.ms/swa/config-schema",
+      "fileMatch": ["staticwebapp.config.json"],
+      "url": "https://json.schemastore.org/staticwebapp.config.json"
+    },
+    {
+      "name": "Azure Static Web Apps CLI configuration file",
+      "description": "Documentation: https://github.com/Azure/static-web-apps-cli#swa-cliconfigjson-file",
+      "fileMatch": ["swa-cli.config.json"],
+      "url": "https://json.schemastore.org/swa-cli.config.json"
+    },
+    {
+      "name": "Stale",
+      "description": "Configuration file for Stale for closing abandoned issues and pull requests. See https://probot.github.io/apps/stale/.",
+      "fileMatch": ["**/.github/stale.yml"],
+      "url": "https://json.schemastore.org/stale.json"
+    },
+    {
+      "name": "Starship",
+      "description": "Configuration file for Starship. See https://starship.rs.",
+      "fileMatch": ["starship.toml"],
+      "url": "https://starship.rs/config-schema.json"
+    },
+    {
+      "name": "Statamic Blueprint",
+      "description": "A Statamic Blueprint Schema",
+      "fileMatch": [
+        "**/resources/blueprints/**/*.yml",
+        "**/resources/blueprints/**/*.yaml"
+      ],
+      "url": "https://raw.githubusercontent.com/Konafets/statamic-blueprint-validation/main/statamic.blueprint.schema.json"
+    },
+    {
+      "name": "stripe-app.json",
+      "description": "Stripe Apps manifest file",
+      "fileMatch": ["stripe-app.json"],
+      "url": "https://raw.githubusercontent.com/stripe/stripe-apps/main/schema/stripe-app.schema.json"
+    },
+    {
+      "name": "stripe-app-local.json",
+      "description": "Stripe Apps local manifest file",
+      "fileMatch": ["stripe-app.*.json"],
+      "url": "https://raw.githubusercontent.com/stripe/stripe-apps/main/schema/stripe-app-local.schema.json"
+    },
+    {
+      "name": "Stryker Mutator",
+      "description": "Configuration file for Stryker Mutator, the mutation testing framework for JavaScript and friends. See https://stryker-mutator.io.",
+      "fileMatch": ["stryker.conf.json", "stryker-*.conf.json"],
+      "url": "https://raw.githubusercontent.com/stryker-mutator/stryker/master/packages/api/schema/stryker-core.json"
+    },
+    {
+      "name": "StyleCop Analyzers Configuration",
+      "description": "Configuration file for StyleCop Analyzers",
+      "fileMatch": ["stylecop.json"],
+      "url": "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/master/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json"
+    },
+    {
+      "name": ".stylelintrc",
+      "description": "Configuration file for stylelint",
+      "fileMatch": [
+        ".stylelintrc",
+        ".stylelintrc.yml",
+        ".stylelintrc.yaml",
+        ".stylelintrc.json"
+      ],
+      "url": "https://json.schemastore.org/stylelintrc.json"
+    },
+    {
+      "name": "SWADL",
+      "description": "Symphony Workflow Automation Definition Language. See https://developers.symphony.com/",
+      "fileMatch": ["*.swadl.yaml", "*.swadl.yml"],
+      "url": "https://raw.githubusercontent.com/SymphonyPlatformSolutions/symphony-wdk/master/workflow-language/src/main/resources/swadl-schema-1.0.json"
+    },
+    {
+      "name": "Swagger API 2.0",
+      "description": "Swagger API 2.0 schema",
+      "fileMatch": ["swagger.json"],
+      "url": "https://json.schemastore.org/swagger-2.0.json"
+    },
+    {
+      "name": "Talisman configuration",
+      "description": "Configuration for .talismanrc",
+      "fileMatch": [".talismanrc"],
+      "url": "https://raw.githubusercontent.com/thoughtworks/talisman/main/examples/schema-store-talismanrc.json"
+    },
+    {
+      "name": "Taurus",
+      "description": "Taurus bzt cli framework config",
+      "fileMatch": ["bzt.yml", "bzt.yaml", "taurus.yml", "taurus.yaml"],
+      "url": "https://json.schemastore.org/taurus.json"
+    },
+    {
+      "name": "template.json",
+      "description": "JSON schema .NET template files",
+      "fileMatch": ["**/.template.config/template.json"],
+      "url": "https://json.schemastore.org/template.json"
+    },
+    {
+      "name": "templatsources.json",
+      "description": "SideWaffle template source schema",
+      "fileMatch": ["templatesources.json"],
+      "url": "https://json.schemastore.org/templatesources.json"
+    },
+    {
+      "name": "Tikibase",
+      "description": "Tikibase configuration file",
+      "fileMatch": ["tikibase.json"],
+      "url": "https://raw.githubusercontent.com/kevgo/tikibase/main/doc/tikibase.schema.json"
+    },
+    {
+      "name": "theme.json",
+      "description": "WordPress block theme global settings and styles configuration file",
+      "fileMatch": ["theme.json"],
+      "url": "https://schemas.wp.org/trunk/theme.json",
+      "versions": {
+        "v1": "https://raw.githubusercontent.com/WordPress/gutenberg/b40b61fabf13a6229c616527689d9a7024f81535/schemas/json/theme.json",
+        "trunk": "https://raw.githubusercontent.com/WordPress/gutenberg/trunk/schemas/json/theme.json"
+      }
+    },
+    {
+      "name": "tizen_workspace.json",
+      "description": "Tizen project workspace configuration file",
+      "fileMatch": ["tizen_workspace.yaml"],
+      "url": "https://json.schemastore.org/tizen_workspace.json"
+    },
+    {
+      "name": "tmLanguage",
+      "description": "Language grammar description files in Textmate and compatible editors",
+      "fileMatch": ["*.tmLanguage.json"],
+      "url": "https://raw.githubusercontent.com/Septh/tmlanguage/master/tmLanguage.schema.json"
+    },
+    {
+      "name": "TestEnvironment.json",
+      "description": "Schema for Visual Studio's test environment config",
+      "fileMatch": ["testEnvironments.json"],
+      "url": "https://json.schemastore.org/testenvironments.json"
+    },
+    {
+      "name": "Turborepo",
+      "description": "TurboRepo, a tool for managing monorepos",
+      "fileMatch": ["turbo.json"],
+      "url": "https://turborepo.org/schema.json"
+    },
+    {
+      "name": ".travis.yml",
+      "description": "Travis CI configuration file",
+      "fileMatch": [".travis.yml"],
+      "url": "https://json.schemastore.org/travis.json"
+    },
+    {
+      "name": "Traefik v2",
+      "description": "Traefik v2 YAML configuration file",
+      "fileMatch": ["traefik.yml", "traefik.yaml"],
+      "url": "https://json.schemastore.org/traefik-v2.json"
+    },
+    {
+      "name": "Traefik v2 File Provider",
+      "description": "Traefik v2 Dynamic Configuration File Provider",
+      "url": "https://json.schemastore.org/traefik-v2-file-provider.json"
+    },
+    {
+      "name": "trunk.yaml schema",
+      "description": "Configuration schema for trunk, a powerful linter runner - https://docs.trunk.io",
+      "fileMatch": ["trunk.yaml"],
+      "url": "https://static.trunk.io/pub/trunk-yaml-schema.json"
+    },
+    {
+      "name": "tsconfig.json",
+      "description": "TypeScript compiler configuration file",
+      "fileMatch": ["tsconfig*.json"],
+      "url": "https://json.schemastore.org/tsconfig.json"
+    },
+    {
+      "name": "tsd.json",
+      "description": "JSON schema for DefinitelyTyped description manager (TSD)",
+      "fileMatch": ["tsd.json"],
+      "url": "https://json.schemastore.org/tsd.json"
+    },
+    {
+      "name": "tsdrc.json",
+      "description": "TypeScript Definition manager (tsd) global settings file",
+      "fileMatch": [".tsdrc"],
+      "url": "https://json.schemastore.org/tsdrc.json"
+    },
+    {
+      "name": "ts-force-config.json",
+      "description": "Generated Typescript classes for Salesforce",
+      "fileMatch": ["ts-force-config.json"],
+      "url": "https://json.schemastore.org/ts-force-config.json"
+    },
+    {
+      "name": "tslint.json",
+      "description": "TypeScript Lint configuration file",
+      "fileMatch": ["tslint.json", "tslint.yaml", "tslint.yml"],
+      "url": "https://json.schemastore.org/tslint.json"
+    },
+    {
+      "name": "TSON",
+      "description": "Schema for TSON (Tuning-Spectrum Object Notation) data",
+      "fileMatch": ["*.tson", "*.tson.yaml", "*.tson.yml", "*.tson.json"],
+      "url": "https://raw.githubusercontent.com/spectral-discord/TSON/main/schema/tson.json"
+    },
+    {
+      "name": "typewiz.json",
+      "description": "Typewiz configuration file",
+      "fileMatch": ["typewiz.json"],
+      "url": "https://json.schemastore.org/typewiz.json"
+    },
+    {
+      "name": "typo3.json",
+      "description": "Schema for the Typo3 CMS",
+      "fileMatch": ["**/sites/*/config.yaml", "**/sites/*/config.yml"],
+      "url": "https://json.schemastore.org/typo3.json"
+    },
+    {
+      "name": "typings.json",
+      "description": "Typings TypeScript definitions manager definition file",
+      "fileMatch": ["typings.json"],
+      "url": "https://json.schemastore.org/typings.json"
+    },
+    {
+      "name": "typingsrc.json",
+      "description": "Typings TypeScript definitions manager configuration file",
+      "fileMatch": [".typingsrc"],
+      "url": "https://json.schemastore.org/typingsrc.json"
+    },
+    {
+      "name": "Ubuntu Server Autoinstall",
+      "description": "Settings file for Ubuntu Autoinstall",
+      "fileMatch": ["user-data"],
+      "url": "https://json.schemastore.org/ubuntu-server-autoinstall.json"
+    },
+    {
+      "name": "up.json",
+      "description": "Up configuration file",
+      "fileMatch": ["up.json"],
+      "url": "https://json.schemastore.org/up.json"
+    },
+    {
+      "name": "UI5 Manifest",
+      "description": "UI5 Manifest (manifest.json)",
+      "fileMatch": [
+        "**/webapp/manifest.json",
+        "**/src/main/webapp/manifest.json",
+        "**/src/manifest.json"
+      ],
+      "url": "https://raw.githubusercontent.com/SAP/ui5-manifest/master/schema.json"
+    },
+    {
+      "name": "ui5.yaml",
+      "description": "UI5 Tooling Configuration File (ui5.yaml)",
+      "fileMatch": [
+        "ui5.yaml",
+        "*-ui5.yaml",
+        "*.ui5.yaml",
+        "ui5-deploy.yaml",
+        "ui5-dist.yaml",
+        "ui5-local.yaml"
+      ],
+      "url": "https://sap.github.io/ui5-tooling/schema/ui5.yaml.json"
+    },
+    {
+      "name": "UTAM Page Object",
+      "description": "UI Test Automation Model page object - https://utam.dev/",
+      "fileMatch": ["*.utam.json", ".utam.json"],
+      "url": "https://json.schemastore.org/utam-page-object.json"
+    },
+    {
+      "name": "vega.json",
+      "description": "Vega visualization specification file",
+      "fileMatch": ["*.vg", "*.vg.json"],
+      "url": "https://json.schemastore.org/vega.json"
+    },
+    {
+      "name": "vega-lite.json",
+      "description": "Vega-Lite visualization specification file",
+      "fileMatch": ["*.vl", "*.vl.json"],
+      "url": "https://json.schemastore.org/vega-lite.json"
+    },
+    {
+      "name": "Vela Pipeline Configuration",
+      "description": "Vela Pipeline Configuration File",
+      "fileMatch": [".vela.yml", ".vela.yaml"],
+      "url": "https://github.com/go-vela/types/releases/latest/download/schema.json"
+    },
+    {
+      "name": "venvironment.yaml",
+      "description": "Simulation and test environment for Vector CANoe4SW Server Edition",
+      "fileMatch": [
+        "venvironment.yaml",
+        "*.venvironment.yaml",
+        "venvironment.yml",
+        "*.venvironment.yml",
+        "venvironment.json",
+        "*.venvironment.json"
+      ],
+      "url": "https://json.schemastore.org/venvironment-schema.json"
+    },
+    {
+      "name": "venvironment-basic.yaml",
+      "description": "Test environment for Vector Test Unit Runner",
+      "fileMatch": [
+        "venvironment-basic.yaml",
+        "*.venvironment-basic.yaml",
+        "venvironment-basic.yml",
+        "*.venvironment-basic.yml",
+        "venvironment-basic.json",
+        "*.venvironment-basic.json"
+      ],
+      "url": "https://json.schemastore.org/venvironment-basic-schema.json"
+    },
+    {
+      "name": "version.json",
+      "description": "A project version descriptor file used by Nerdbank.GitVersioning",
+      "fileMatch": ["version.json"],
+      "url": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json"
+    },
+    {
+      "name": "vim-addon-info",
+      "description": "JSON schema for vim plugin addon-info.json metadata files",
+      "fileMatch": ["**/*vim*/addon-info.json"],
+      "url": "https://json.schemastore.org/vim-addon-info.json"
+    },
+    {
+      "name": "vsls.json",
+      "description": "Visual Studio Live Share configuration file",
+      "fileMatch": [".vsls.json"],
+      "url": "https://json.schemastore.org/vsls.json"
+    },
+    {
+      "name": "vs-2017.3.host.json",
+      "description": "JSON schema for Visual Studio template host file",
+      "fileMatch": ["vs-2017.3.host.json"],
+      "url": "https://json.schemastore.org/vs-2017.3.host.json"
+    },
+    {
+      "name": "vs-nesting.json",
+      "description": "JSON schema for Visual Studio's file nesting feature",
+      "fileMatch": ["*.filenesting.json", ".filenesting.json"],
+      "url": "https://json.schemastore.org/vs-nesting.json"
+    },
+    {
+      "name": ".vsconfig",
+      "description": "JSON schema for Visual Studio component configuration files",
+      "fileMatch": ["*.vsconfig"],
+      "url": "https://json.schemastore.org/vsconfig.json"
+    },
+    {
+      "name": ".vsext",
+      "description": "JSON schema for Visual Studio extension pack manifests",
+      "fileMatch": ["*.vsext"],
+      "url": "https://json.schemastore.org/vsext.json"
+    },
+    {
+      "name": "VSIX CLI publishing",
+      "description": "JSON schema for Visual Studio extension publishing",
+      "fileMatch": ["vs-publish.json"],
+      "url": "https://json.schemastore.org/vsix-publish.json"
+    },
+    {
+      "name": "vss-extension.json",
+      "description": "JSON Schema for Azure DevOps Extensions",
+      "fileMatch": ["vss-extension.json"],
+      "url": "https://json.schemastore.org/vss-extension.json"
+    },
+    {
+      "name": "v8r",
+      "description": "v8r configuration file schema",
+      "fileMatch": [".v8rrc.json", ".v8rrc.yaml", ".v8rrc.yml"],
+      "url": "https://raw.githubusercontent.com/chris48s/v8r/main/config-schema.json"
+    },
+    {
+      "name": "<div>RIOTS' studio configuration",
+      "description": "JSON schema for the <div>RIOTS' studio configuration",
+      "fileMatch": ["studio.config.json"],
+      "url": "https://webcomponents.dev/assets2/schemas/studio.config.json"
+    },
+    {
+      "name": "WebExtensions",
+      "description": "JSON schema for WebExtension manifest files",
+      "fileMatch": ["manifest.json"],
+      "url": "https://json.schemastore.org/webextension.json"
+    },
+    {
+      "name": "Web App Manifest",
+      "description": "Web Application manifest file",
+      "fileMatch": ["manifest.json", "*.webmanifest"],
+      "url": "https://json.schemastore.org/web-manifest-combined.json"
+    },
+    {
+      "name": "webjobs-list.json",
+      "description": "Azure Webjob list file",
+      "fileMatch": ["webjobs-list.json"],
+      "url": "https://json.schemastore.org/webjobs-list.json"
+    },
+    {
+      "name": "webjobpublishsettings.json",
+      "description": "Azure Webjobs publish settings file",
+      "fileMatch": ["webjobpublishsettings.json"],
+      "url": "https://json.schemastore.org/webjob-publish-settings.json"
+    },
+    {
+      "name": "Web types",
+      "description": "JSON standard for web component libraries metadata",
+      "fileMatch": ["web-types.json", "*.web-types.json"],
+      "url": "https://json.schemastore.org/web-types.json"
+    },
+    {
+      "name": "JSON-stat 2.0",
+      "description": "JSON-stat 2.0 Schema",
+      "url": "https://json-stat.org/format/schema/2.0/"
+    },
+    {
+      "name": "KSP-AVC",
+      "description": "The .version file format for KSP-AVC",
+      "fileMatch": ["*.version"],
+      "url": "https://raw.githubusercontent.com/linuxgurugamer/KSPAddonVersionChecker/master/KSP-AVC.schema.json"
+    },
+    {
+      "name": "KSP-CKAN",
+      "description": "Metadata spec for KSP-CKAN",
+      "fileMatch": ["*.ckan"],
+      "url": "https://raw.githubusercontent.com/KSP-CKAN/CKAN/master/CKAN.schema"
+    },
+    {
+      "name": "JSON Schema Draft 4",
+      "description": "Meta-validation schema for JSON Schema Draft 4",
+      "url": "https://json-schema.org/draft-04/schema"
+    },
+    {
+      "name": "JSON Schema Draft 7",
+      "description": "Meta-validation schema for JSON Schema Draft 7",
+      "fileMatch": ["*.schema.json"],
+      "url": "https://json-schema.org/draft-07/schema"
+    },
+    {
+      "name": "JSON Schema Draft 8",
+      "description": "Meta-validation schema for JSON Schema Draft 8",
+      "url": "https://json-schema.org/draft/2019-09/schema"
+    },
+    {
+      "name": "JSON Schema Draft 2020-12",
+      "description": "Meta-validation schema for JSON Schema Draft 2020-12",
+      "url": "https://json-schema.org/draft/2020-12/schema"
+    },
+    {
+      "name": "xunit.runner.json",
+      "description": "Configuration file for unit test projects using xUnit.net",
+      "fileMatch": ["xunit.runner.json", "*.xunit.runner.json"],
+      "url": "https://json.schemastore.org/xunit.runner.schema.json",
+      "versions": {
+        "v2.2": "https://xunit.net/schema/v2.2/xunit.runner.schema.json",
+        "v2.3": "https://xunit.net/schema/v2.3/xunit.runner.schema.json",
+        "v2.4": "https://xunit.net/schema/current/xunit.runner.schema.json"
+      }
+    },
+    {
+      "name": "servicehub.service.json",
+      "description": "Microsoft ServiceHub Service",
+      "fileMatch": ["*.servicehub.service.json"],
+      "url": "https://json.schemastore.org/servicehub.service.schema.json"
+    },
+    {
+      "name": "servicehub.config.json",
+      "description": "Microsoft ServiceHub Configuration",
+      "fileMatch": ["servicehub.config.json"],
+      "url": "https://json.schemastore.org/servicehub.config.schema.json"
+    },
+    {
+      "name": ".cryproj engine-5.2",
+      "description": "A JSON schema for CRYENGINE projects (.cryproj files)",
+      "fileMatch": ["*.cryproj"],
+      "url": "https://json.schemastore.org/cryproj.52.schema.json"
+    },
+    {
+      "name": ".cryproj engine-5.3",
+      "description": "A JSON schema for CRYENGINE projects (.cryproj files)",
+      "fileMatch": ["*.cryproj"],
+      "url": "https://json.schemastore.org/cryproj.53.schema.json"
+    },
+    {
+      "name": ".cryproj engine-5.4",
+      "description": "A JSON schema for CRYENGINE projects (.cryproj files)",
+      "fileMatch": ["*.cryproj"],
+      "url": "https://json.schemastore.org/cryproj.54.schema.json"
+    },
+    {
+      "name": ".cryproj engine-5.5",
+      "description": "A JSON schema for CRYENGINE projects (.cryproj files)",
+      "fileMatch": ["*.cryproj"],
+      "url": "https://json.schemastore.org/cryproj.55.schema.json"
+    },
+    {
+      "name": ".cryproj engine-dev",
+      "description": "A JSON schema for CRYENGINE projects (.cryproj files)",
+      "fileMatch": ["*.cryproj"],
+      "url": "https://json.schemastore.org/cryproj.dev.schema.json"
+    },
+    {
+      "name": ".cryproj (generic)",
+      "description": "A JSON schema for CRYENGINE projects (.cryproj files)",
+      "fileMatch": ["*.cryproj"],
+      "url": "https://json.schemastore.org/cryproj.json"
+    },
+    {
+      "name": "typedoc.json",
+      "description": "A JSON schema for the Typedoc configuration file",
+      "fileMatch": ["typedoc.json"],
+      "url": "https://typedoc.org/schema.json"
+    },
+    {
+      "name": "tmuxinator",
+      "description": "Schema for tmuxinator, a tmux session manager",
+      "fileMatch": [
+        ".tmuxinator.yaml",
+        ".tmuxinator.yml",
+        "**/.tmuxinator/*.yaml",
+        "**/.tmuxinator/*.yml",
+        "**/tmuxinator/*.yaml",
+        "**/tmuxinator/*.yml"
+      ],
+      "url": "https://json.schemastore.org/tmuxinator.json"
+    },
+    {
+      "name": "huskyrc",
+      "description": "Husky can prevent bad `git commit`, `git push` and more 🐶 woof!",
+      "fileMatch": [".huskyrc", ".huskyrc.json"],
+      "url": "https://json.schemastore.org/huskyrc.json"
+    },
+    {
+      "name": ".lintstagedrc",
+      "description": "JSON schema for lint-staged config",
+      "fileMatch": [".lintstagedrc", ".lintstagedrc.json"],
+      "url": "https://json.schemastore.org/lintstagedrc.schema.json"
+    },
+    {
+      "name": "mirrord-schema",
+      "description": "Schema for mirrord.",
+      "fileMatch": ["*.mirrord.+(toml|json|y?(a)ml)"],
+      "url": "https://raw.githubusercontent.com/metalbear-co/mirrord/main/mirrord-schema.json"
+    },
+    {
+      "name": "mta.yaml",
+      "description": "A JSON schema for MTA projects v3.3",
+      "fileMatch": ["mta.yaml", "mta.yml"],
+      "url": "https://json.schemastore.org/mta.json"
+    },
+    {
+      "name": "mtad.yaml",
+      "description": "A JSON schema for MTA deployment descriptors v3.3",
+      "fileMatch": ["mtad.yaml", "mtad.yml"],
+      "url": "https://json.schemastore.org/mtad.json"
+    },
+    {
+      "name": "Motif config",
+      "description": "A JSON schema for a Motif config file.",
+      "fileMatch": ["motif.json"],
+      "url": "https://motif.land/api/motif.schema.json"
+    },
+    {
+      "name": ".mtaext",
+      "description": "A JSON schema for MTA extension descriptors v3.3",
+      "fileMatch": ["*.mtaext"],
+      "url": "https://json.schemastore.org/mtaext.json"
+    },
+    {
+      "name": "xs-app.json",
+      "description": "JSON schema for the SAP Application Router v8.2.2",
+      "fileMatch": ["xs-app.json"],
+      "url": "https://json.schemastore.org/xs-app.json"
+    },
+    {
+      "name": "Opctl",
+      "description": "Opctl schema for describing an op",
+      "url": "https://json.schemastore.org/opspec-io-0.1.7.json",
+      "fileMatch": ["**/.opspec/*/*.yml", "**/.opspec/*/*.yaml"]
+    },
+    {
+      "name": "HEMTT",
+      "description": "HEMTT Project File",
+      "url": "https://json.schemastore.org/hemtt-0.6.2.json",
+      "fileMatch": ["hemtt.json", "hemtt.toml"],
+      "versions": {
+        "0.6.2": "https://json.schemastore.org/hemtt-0.6.2.json"
+      }
+    },
+    {
+      "name": "now",
+      "description": "ZEIT Now project configuration file",
+      "fileMatch": ["now.json"],
+      "url": "https://json.schemastore.org/now.json"
+    },
+    {
+      "name": "taskcat",
+      "description": "taskcat",
+      "fileMatch": [".taskcat.yml"],
+      "url": "https://raw.githubusercontent.com/aws-quickstart/taskcat/master/taskcat/cfg/config_schema.json"
+    },
+    {
+      "name": "BizTalkServerApplicationSchema",
+      "description": "BizTalk server application inventory json file.",
+      "fileMatch": ["BizTalkServerInventory.json"],
+      "url": "https://json.schemastore.org/BizTalkServerApplicationSchema.json"
+    },
+    {
+      "name": "httpmockrc",
+      "description": "Http-mocker is a tool for mock local requests or proxy remote requests.",
+      "fileMatch": [".httpmockrc", ".httpmock.json"],
+      "url": "https://json.schemastore.org/httpmockrc.json"
+    },
+    {
+      "name": "neoload",
+      "description": "Neotys as-code load test specification, more at: https://github.com/Neotys-Labs/neoload-cli",
+      "fileMatch": [
+        ".nl.yaml",
+        ".nl.yml",
+        ".nl.json",
+        ".neoload.yaml",
+        ".neoload.yml",
+        ".neoload.json"
+      ],
+      "url": "https://raw.githubusercontent.com/Neotys-Labs/neoload-cli/master/resources/as-code.latest.schema.json"
+    },
+    {
+      "name": "release drafter",
+      "description": "Release Drafter configuration file",
+      "fileMatch": ["**/.github/release-drafter.yml"],
+      "url": "https://raw.githubusercontent.com/release-drafter/release-drafter/master/schema.json"
+    },
+    {
+      "name": "zuul",
+      "description": "Zuul CI configuration file",
+      "fileMatch": ["**/*zuul.d/*.yaml", ".zuul.yaml"],
+      "url": "https://json.schemastore.org/zuul.json"
+    },
+    {
+      "name": "Briefcase",
+      "description": "Microsoft Briefcase configuration file",
+      "fileMatch": ["briefcase.yaml"],
+      "url": "https://raw.githubusercontent.com/microsoft/Briefcase/master/mlbriefcase/briefcase-schema.json"
+    },
+    {
+      "name": "httparchive",
+      "description": "HTTP Archive",
+      "fileMatch": ["*.har"],
+      "url": "https://raw.githubusercontent.com/ahmadnassri/har-schema/master/lib/har.json"
+    },
+    {
+      "name": "jsdoc",
+      "description": "JSDoc configuration file",
+      "fileMatch": ["conf.js*", "jsdoc.js*"],
+      "url": "https://json.schemastore.org/jsdoc-1.0.0.json"
+    },
+    {
+      "name": "Ray",
+      "description": "Ray autocluster configuration file",
+      "fileMatch": ["ray-*-cluster.yaml"],
+      "url": "https://raw.githubusercontent.com/ray-project/ray/master/python/ray/autoscaler/ray-schema.json"
+    },
+    {
+      "name": "Hadolint",
+      "description": "A smarter Dockerfile linter that helps you build best practice Docker images.",
+      "fileMatch": [
+        ".hadolint.yaml",
+        "hadolint.yaml",
+        ".hadolint.yml",
+        "hadolint.yml"
+      ],
+      "url": "https://raw.githubusercontent.com/hadolint/hadolint/master/contrib/hadolint.json"
+    },
+    {
+      "name": "helmfile",
+      "description": "Helmfile is a declarative spec for deploying helm charts",
+      "fileMatch": ["helmfile.yaml", "**/helmfile.d/**/*.yaml"],
+      "url": "https://json.schemastore.org/helmfile.json"
+    },
+    {
+      "name": "Container Structure Test",
+      "description": "The Container Structure Tests provide a powerful framework to validate the structure of a container image.",
+      "fileMatch": ["container-structure-test.yaml", "structure-test.yaml"],
+      "url": "https://json.schemastore.org/container-structure-test.json"
+    },
+    {
+      "name": "Žinoma",
+      "description": "Žinoma incremental build configuration",
+      "fileMatch": ["zinoma.yml"],
+      "url": "https://github.com/fbecart/zinoma/releases/latest/download/zinoma-schema.json"
+    },
+    {
+      "name": "Windows Package Manager Singleton Manifest",
+      "description": "Windows Package Manager Singleton Manifest file",
+      "url": "https://json.schemastore.org/winget-pkgs-singleton-1.0.0.json",
+      "fileMatch": ["**/manifests/?/*/*/*/*.*.yaml"],
+      "versions": {
+        "0.1": "https://json.schemastore.org/winget-pkgs-singleton-0.1.json",
+        "1.0.0": "https://json.schemastore.org/winget-pkgs-singleton-1.0.0.json"
+      }
+    },
+    {
+      "name": "Windows Package Manager Installer Manifest",
+      "description": "Windows Package Manager Installer Manifest file, used for detailing installer specific metadata.",
+      "url": "https://json.schemastore.org/winget-pkgs-installer-1.0.0.json",
+      "fileMatch": ["**/manifests/?/*/*/*/*.*.installer.yaml"]
+    },
+    {
+      "name": "Windows Package Manager Locale Manifest",
+      "description": "Windows Package Manager Locale Manifest file, used for detailing locale specific metadata.",
+      "url": "https://json.schemastore.org/winget-pkgs-locale-1.0.0.json",
+      "fileMatch": [
+        "**/manifests/?/*/*/*/*.*.locale@(.en-US|fr-FR|it-IT|ja-JP|ko-KR|pt-BR|ru-RU|zh-CN|zh-TW).yaml"
+      ]
+    },
+    {
+      "name": ".commitlintrc",
+      "description": "JSON schema for commitlint configuration files",
+      "fileMatch": [".commitlintrc", ".commitlintrc.json"],
+      "url": "https://json.schemastore.org/commitlintrc.json"
+    },
+    {
+      "name": "Uniswap Token List",
+      "description": "A list of tokens compatible with the Uniswap Interface",
+      "fileMatch": ["*.tokenlist.json"],
+      "url": "https://uniswap.org/tokenlist.schema.json"
+    },
+    {
+      "name": "yamllint",
+      "description": "yamllint uses a set of rules to check source files for problems",
+      "fileMatch": ["**/.yamllint", "**/.yamllint.yaml", "**/.yamllint.yml"],
+      "url": "https://json.schemastore.org/yamllint.json"
+    },
+    {
+      "name": "Yippee-Ki-JSON configuration YML",
+      "description": "Action and rule configuration descriptor for Yippee-Ki-JSON transformations.",
+      "fileMatch": ["**/yippee-*.yml", "**/*.yippee.yml"],
+      "url": "https://raw.githubusercontent.com/nagyesta/yippee-ki-json/main/schema/yippee-ki-json_config_schema.json",
+      "versions": {
+        "1.1.2": "https://raw.githubusercontent.com/nagyesta/yippee-ki-json/v1.1.2/schema/yippee-ki-json_config_schema.json",
+        "latest": "https://raw.githubusercontent.com/nagyesta/yippee-ki-json/main/schema/yippee-ki-json_config_schema.json"
+      }
+    },
+    {
+      "name": "docker-compose.yml",
+      "description": "The Compose specification establishes a standard for the definition of multi-container platform-agnostic applications. ",
+      "fileMatch": [
+        "**/docker-compose.yml",
+        "**/docker-compose.yaml",
+        "**/docker-compose.*.yml",
+        "**/docker-compose.*.yaml",
+        "**/compose.yml",
+        "**/compose.yaml",
+        "**/compose.*.yml",
+        "**/compose.*.yaml"
+      ],
+      "url": "https://raw.githubusercontent.com/compose-spec/compose-spec/master/schema/compose-spec.json"
+    },
+    {
+      "name": "devinit",
+      "description": "Devinit configuration file schema.",
+      "url": "https://json.schemastore.org/devinit.schema-6.0.json",
+      "fileMatch": ["devinit.json", ".devinit.json"],
+      "versions": {
+        "1.0": "https://json.schemastore.org/devinit.schema-1.0.json",
+        "2.0": "https://json.schemastore.org/devinit.schema-2.0.json",
+        "3.0": "https://json.schemastore.org/devinit.schema-3.0.json",
+        "4.0": "https://json.schemastore.org/devinit.schema-4.0.json",
+        "5.0": "https://json.schemastore.org/devinit.schema-5.0.json",
+        "6.0": "https://json.schemastore.org/devinit.schema-6.0.json"
+      }
+    },
+    {
+      "name": "tsoa",
+      "description": "JSON Schema for the tsoa configuration file",
+      "url": "https://json.schemastore.org/tsoa.json",
+      "fileMatch": ["**/tsoa.json"]
+    },
+    {
+      "name": "API Builder",
+      "description": "apibuilder.io schema",
+      "fileMatch": ["**/api.json"],
+      "url": "https://json.schemastore.org/apibuilder.json"
+    },
+    {
+      "name": "Gradle Enterprise",
+      "description": "Gradle Enterprise configuration schema",
+      "fileMatch": ["*gradle-enterprise.yml", "*gradle-enterprise.yaml"],
+      "url": "https://docs.gradle.com/enterprise/admin/schema/gradle-enterprise-config-schema-5.json",
+      "versions": {
+        "1.0": "https://docs.gradle.com/enterprise/admin/schema/gradle-enterprise-config-schema-1.json",
+        "2.0": "https://docs.gradle.com/enterprise/admin/schema/gradle-enterprise-config-schema-2.json",
+        "3.0": "https://docs.gradle.com/enterprise/admin/schema/gradle-enterprise-config-schema-3.json",
+        "4.0": "https://docs.gradle.com/enterprise/admin/schema/gradle-enterprise-config-schema-4.json",
+        "5.0": "https://docs.gradle.com/enterprise/admin/schema/gradle-enterprise-config-schema-5.json"
+      }
+    },
+    {
+      "name": "Gradle Build Cache Node",
+      "description": "Gradle Build Cache Node configuration schema",
+      "fileMatch": [
+        "*build-cache-node-config.yml",
+        "*build-cache-node-config.yaml"
+      ],
+      "url": "https://docs.gradle.com/build-cache-node/schema/build-cache-node-config-schema-5.json",
+      "versions": {
+        "1.0": "https://docs.gradle.com/build-cache-node/schema/build-cache-node-config-schema-1.json",
+        "2.0": "https://docs.gradle.com/build-cache-node/schema/build-cache-node-config-schema-2.json",
+        "3.0": "https://docs.gradle.com/build-cache-node/schema/build-cache-node-config-schema-3.json",
+        "4.0": "https://docs.gradle.com/build-cache-node/schema/build-cache-node-config-schema-4.json",
+        "5.0": "https://docs.gradle.com/build-cache-node/schema/build-cache-node-config-schema-5.json"
+      }
+    },
+    {
+      "name": ".yarnrc.yml",
+      "description": "JSON Schema for Yarnrc files",
+      "fileMatch": [".yarnrc.yml"],
+      "url": "https://yarnpkg.com/configuration/yarnrc.json"
+    },
+    {
+      "name": "beau.yml",
+      "description": "JSON Schema for a Beaujs Requests file.",
+      "fileMatch": ["beau.yml"],
+      "url": "https://beaujs.com/schema.json"
+    },
+    {
+      "name": "Better Code Hub",
+      "description": "Configuration file for Better Code Hub to override the default configuration.",
+      "fileMatch": [".bettercodehub.yml"],
+      "url": "https://json.schemastore.org/bettercodehub.json"
+    },
+    {
+      "name": "comet",
+      "description": "JSON Schema for a Comet Data Pipeline.",
+      "fileMatch": ["*.comet.yaml", "*.comet.yml"],
+      "url": "https://json.schemastore.org/comet.json"
+    },
+    {
+      "name": "swcrc",
+      "description": "JSON Schema for swc configuration files.",
+      "fileMatch": [".swcrc"],
+      "url": "https://json.schemastore.org/swcrc.json"
+    },
+    {
+      "name": "OpenWeather Road Risk API",
+      "description": "JSON Schema for OpenWeather Road Risk API responses.",
+      "fileMatch": [],
+      "url": "https://json.schemastore.org/openweather.roadrisk.json"
+    },
+    {
+      "name": "OpenWeather Current Weather API",
+      "description": "JSON Schema for OpenWeather Current Weather API responses.",
+      "fileMatch": [],
+      "url": "https://json.schemastore.org/openweather.current.json"
+    },
+    {
+      "name": "JSON-e templates",
+      "description": "JSON Schema for JSON-e templates.",
+      "fileMatch": [],
+      "url": "https://json.schemastore.org/jsone.json"
+    },
+    {
+      "name": "Taskfile YAML Schema",
+      "description": "JSON Schema for Taskfile files.",
+      "fileMatch": [
+        "Taskfile.yaml",
+        "Taskfile.dist.yaml",
+        "Taskfile.yml",
+        "Taskfile.dist.yml"
+      ],
+      "url": "https://taskfile.dev/schema.json"
+    },
+    {
+      "name": "Hammerkit",
+      "description": "JSON Schema for hammerkit files.",
+      "fileMatch": [
+        ".hammerkit.yaml",
+        ".hammerkit.yml",
+        "*.hammerkit.yaml",
+        "*.hammerkit.yml"
+      ],
+      "url": "https://json.schemastore.org/hammerkit.json"
+    },
+    {
+      "name": "Containerlab",
+      "description": "JSON Schema for Containerlab topology definition files.",
+      "fileMatch": ["*-clab.yaml", "*-clab.yml", "*.clab.yaml", "*.clab.yml"],
+      "url": "https://raw.githubusercontent.com/srl-labs/containerlab/main/schemas/clab.schema.json"
+    },
+    {
+      "name": "User Journey Map YAML Schema",
+      "description": "JSON Schema for user journey map definition files.",
+      "fileMatch": ["*.jm.yaml", "*.jm.yml"],
+      "url": "https://raw.githubusercontent.com/arvinxx/components/master/packages/journey-map/schema/journey-map.schema.json"
+    },
+    {
+      "name": "RKE Cluster Configuration YAML Schema",
+      "description": "YAML Schema for the cluster.yml configuration file for RKE",
+      "fileMatch": ["cluster.yml", "cluster.yaml"],
+      "url": "https://raw.githubusercontent.com/dcermak/vscode-rke-cluster-config/main/schemas/cluster.yml.json"
+    },
+    {
+      "name": "RKE Cluster Configuration JSON Schema",
+      "description": "JSON Schema for the cluster.json configuration file for RKE",
+      "fileMatch": ["cluster.json"],
+      "url": "https://raw.githubusercontent.com/dcermak/vscode-rke-cluster-config/main/schemas/cluster.json"
+    },
+    {
+      "name": "Liquibase",
+      "description": "Use this schema to get auto-suggestions for your liquibase JSON/YAML files.",
+      "fileMatch": [
+        "**/db/changelog/**/*.yaml",
+        "**/db/changelog/**/*.yml",
+        "**/db/changelog/**/*.json"
+      ],
+      "url": "https://json.schemastore.org/liquibase-3.2.json",
+      "versions": {
+        "1.0": "https://json.schemastore.org/liquibase.json",
+        "3.2": "https://json.schemastore.org/liquibase-3.2.json"
+      }
+    },
+    {
+      "name": "Liquibase Flow File",
+      "description": "Use this schema to get what objects are allowed for your liquibase flow JSON/YAML files.",
+      "fileMatch": ["*.flowfile.yaml", "*.flowfile.yml"],
+      "url": "https://www.liquibase.org/json/schema/liquibase-flow-file-latest.json"
+    },
+    {
+      "name": "Pipeline component",
+      "description": "YAML schema for the Kubeflow Pipelines' component.yaml files which describe a pipeline components. Component consists of input/output definitions and the description of the implementation which can either be a containerized command line program or a interconnected graph of tasks. See https://cloud-pipelines.github.io/links/component_authoring_documentation",
+      "fileMatch": [
+        "component.yaml",
+        "kfp_component.yaml",
+        "kfp_component.json"
+      ],
+      "url": "https://raw.githubusercontent.com/Cloud-Pipelines/component_spec_schema/stable/component_spec.json_schema.json"
+    },
+    {
+      "name": "skaffold.yaml",
+      "description": "Schema for the skaffold.yaml configuration file for Skaffold (https://skaffold.dev/)",
+      "fileMatch": ["skaffold.yaml", "skaffold.yml"],
+      "url": "https://raw.githubusercontent.com/GoogleContainerTools/skaffold/main/docs-v2/content/en/schemas/v3.json",
+      "versions": {
+        "v1alpha1": "https://raw.githubusercontent.com/GoogleContainerTools/skaffold/master/docs/content/en/schemas/v1alpha1.json",
+        "v1alpha2": "https://raw.githubusercontent.com/GoogleContainerTools/skaffold/master/docs/content/en/schemas/v1alpha2.json",
+        "v1alpha3": "https://raw.githubusercontent.com/GoogleContainerTools/skaffold/master/docs/content/en/schemas/v1alpha3.json",
+        "v1alpha4": "https://raw.githubusercontent.com/GoogleContainerTools/skaffold/master/docs/content/en/schemas/v1alpha4.json",
+        "v1alpha5": "https://raw.githubusercontent.com/GoogleContainerTools/skaffold/master/docs/content/en/schemas/v1alpha5.json",
+        "v1beta1": "https://raw.githubusercontent.com/GoogleContainerTools/skaffold/master/docs/content/en/schemas/v1beta1.json",
+        "v1beta2": "https://raw.githubusercontent.com/GoogleContainerTools/skaffold/master/docs/content/en/schemas/v1beta2.json",
+        "v1beta3": "https://raw.githubusercontent.com/GoogleContainerTools/skaffold/master/docs/content/en/schemas/v1beta3.json",
+        "v1beta4": "https://raw.githubusercontent.com/GoogleContainerTools/skaffold/master/docs/content/en/schemas/v1beta4.json",
+        "v1beta5": "https://raw.githubusercontent.com/GoogleContainerTools/skaffold/master/docs/content/en/schemas/v1beta5.json",
+        "v1beta6": "https://raw.githubusercontent.com/GoogleContainerTools/skaffold/master/docs/content/en/schemas/v1beta6.json",
+        "v1beta7": "https://raw.githubusercontent.com/GoogleContainerTools/skaffold/master/docs/content/en/schemas/v1beta7.json",
+        "v1beta8": "https://raw.githubusercontent.com/GoogleContainerTools/skaffold/master/docs/content/en/schemas/v1beta8.json",
+        "v1beta9": "https://raw.githubusercontent.com/GoogleContainerTools/skaffold/master/docs/content/en/schemas/v1beta9.json",
+        "v1beta10": "https://raw.githubusercontent.com/GoogleContainerTools/skaffold/master/docs/content/en/schemas/v1beta10.json",
+        "v1beta11": "https://raw.githubusercontent.com/GoogleContainerTools/skaffold/master/docs/content/en/schemas/v1beta11.json",
+        "v1beta12": "https://raw.githubusercontent.com/GoogleContainerTools/skaffold/master/docs/content/en/schemas/v1beta12.json",
+        "v1beta13": "https://raw.githubusercontent.com/GoogleContainerTools/skaffold/master/docs/content/en/schemas/v1beta13.json",
+        "v1beta14": "https://raw.githubusercontent.com/GoogleContainerTools/skaffold/master/docs/content/en/schemas/v1beta14.json",
+        "v1beta15": "https://raw.githubusercontent.com/GoogleContainerTools/skaffold/master/docs/content/en/schemas/v1beta15.json",
+        "v1beta16": "https://raw.githubusercontent.com/GoogleContainerTools/skaffold/master/docs/content/en/schemas/v1beta16.json",
+        "v1beta17": "https://raw.githubusercontent.com/GoogleContainerTools/skaffold/master/docs/content/en/schemas/v1beta17.json",
+        "v1": "https://raw.githubusercontent.com/GoogleContainerTools/skaffold/master/docs/content/en/schemas/v1.json",
+        "v2alpha1": "https://raw.githubusercontent.com/GoogleContainerTools/skaffold/master/docs/content/en/schemas/v2alpha1.json",
+        "v2alpha2": "https://raw.githubusercontent.com/GoogleContainerTools/skaffold/master/docs/content/en/schemas/v2alpha2.json",
+        "v2alpha3": "https://raw.githubusercontent.com/GoogleContainerTools/skaffold/master/docs/content/en/schemas/v2alpha3.json",
+        "v2alpha4": "https://raw.githubusercontent.com/GoogleContainerTools/skaffold/master/docs/content/en/schemas/v2alpha4.json",
+        "v2beta1": "https://raw.githubusercontent.com/GoogleContainerTools/skaffold/master/docs/content/en/schemas/v2beta1.json",
+        "v2beta2": "https://raw.githubusercontent.com/GoogleContainerTools/skaffold/master/docs/content/en/schemas/v2beta2.json",
+        "v2beta3": "https://raw.githubusercontent.com/GoogleContainerTools/skaffold/master/docs/content/en/schemas/v2beta3.json",
+        "v2beta4": "https://raw.githubusercontent.com/GoogleContainerTools/skaffold/master/docs/content/en/schemas/v2beta4.json",
+        "v2beta5": "https://raw.githubusercontent.com/GoogleContainerTools/skaffold/master/docs/content/en/schemas/v2beta5.json",
+        "v2beta6": "https://raw.githubusercontent.com/GoogleContainerTools/skaffold/master/docs/content/en/schemas/v2beta6.json",
+        "v2beta7": "https://raw.githubusercontent.com/GoogleContainerTools/skaffold/master/docs/content/en/schemas/v2beta7.json",
+        "v2beta8": "https://raw.githubusercontent.com/GoogleContainerTools/skaffold/master/docs/content/en/schemas/v2beta8.json",
+        "v2beta9": "https://raw.githubusercontent.com/GoogleContainerTools/skaffold/master/docs/content/en/schemas/v2beta9.json",
+        "v2beta10": "https://raw.githubusercontent.com/GoogleContainerTools/skaffold/master/docs/content/en/schemas/v2beta10.json",
+        "v2beta11": "https://raw.githubusercontent.com/GoogleContainerTools/skaffold/master/docs/content/en/schemas/v2beta11.json",
+        "v2beta12": "https://raw.githubusercontent.com/GoogleContainerTools/skaffold/master/docs/content/en/schemas/v2beta12.json",
+        "v2beta13": "https://raw.githubusercontent.com/GoogleContainerTools/skaffold/master/docs/content/en/schemas/v2beta13.json",
+        "v2beta14": "https://raw.githubusercontent.com/GoogleContainerTools/skaffold/master/docs/content/en/schemas/v2beta14.json",
+        "v2beta15": "https://raw.githubusercontent.com/GoogleContainerTools/skaffold/master/docs/content/en/schemas/v2beta15.json",
+        "v2beta16": "https://raw.githubusercontent.com/GoogleContainerTools/skaffold/master/docs/content/en/schemas/v2beta16.json",
+        "v2beta17": "https://raw.githubusercontent.com/GoogleContainerTools/skaffold/master/docs/content/en/schemas/v2beta17.json",
+        "v2beta18": "https://raw.githubusercontent.com/GoogleContainerTools/skaffold/master/docs/content/en/schemas/v2beta18.json",
+        "v2beta19": "https://raw.githubusercontent.com/GoogleContainerTools/skaffold/master/docs/content/en/schemas/v2beta19.json",
+        "v2beta20": "https://raw.githubusercontent.com/GoogleContainerTools/skaffold/master/docs/content/en/schemas/v2beta20.json",
+        "v2beta21": "https://raw.githubusercontent.com/GoogleContainerTools/skaffold/master/docs/content/en/schemas/v2beta21.json",
+        "v2beta22": "https://raw.githubusercontent.com/GoogleContainerTools/skaffold/master/docs/content/en/schemas/v2beta22.json",
+        "v2beta23": "https://raw.githubusercontent.com/GoogleContainerTools/skaffold/master/docs/content/en/schemas/v2beta23.json",
+        "v2beta24": "https://raw.githubusercontent.com/GoogleContainerTools/skaffold/master/docs/content/en/schemas/v2beta24.json",
+        "v2beta25": "https://raw.githubusercontent.com/GoogleContainerTools/skaffold/master/docs/content/en/schemas/v2beta25.json",
+        "v2beta26": "https://raw.githubusercontent.com/GoogleContainerTools/skaffold/master/docs/content/en/schemas/v2beta26.json",
+        "v2beta27": "https://raw.githubusercontent.com/GoogleContainerTools/skaffold/master/docs/content/en/schemas/v2beta27.json",
+        "v2beta28": "https://raw.githubusercontent.com/GoogleContainerTools/skaffold/master/docs/content/en/schemas/v2beta28.json",
+        "v2beta29": "https://raw.githubusercontent.com/GoogleContainerTools/skaffold/master/docs/content/en/schemas/v2beta29.json",
+        "v3": "https://raw.githubusercontent.com/GoogleContainerTools/skaffold/main/docs-v2/content/en/schemas/v3.json"
+      }
+    },
+    {
+      "name": "Markdownlint",
+      "description": "Markdownlint config file schema",
+      "fileMatch": [
+        ".markdownlintrc",
+        ".markdownlint.json",
+        ".markdownlint.jsonc",
+        ".markdownlint.yaml",
+        ".markdownlint.yml"
+      ],
+      "url": "https://raw.githubusercontent.com/DavidAnson/markdownlint/main/schema/markdownlint-config-schema.json"
+    },
+    {
+      "name": "markdown-lint-check",
+      "description": "Schema for markdown-lint-check",
+      "fileMatch": [".markdown-lint-check.json"],
+      "url": "https://json.schemastore.org/markdown-lint-check.json"
+    },
+    {
+      "name": "SauceCTL Configuration",
+      "description": "JSON Schema for SauceCTL configuration files.",
+      "fileMatch": ["**/.sauce/*.yml"],
+      "url": "https://raw.githubusercontent.com/saucelabs/saucectl/main/api/saucectl.schema.json"
+    },
+    {
+      "name": "fulibWorkflows",
+      "description": "JSON Schema for fulibWorkflows",
+      "fileMatch": ["*.es.yaml", "*.es.yml"],
+      "url": "https://raw.githubusercontent.com/fujaba/fulibWorkflows/main/schemas/fulibWorkflows.schema.json"
+    },
+    {
+      "name": "Woodpecker pipeline config",
+      "description": "YAML schema for configuring Woodpecker CI",
+      "fileMatch": [
+        "**/.woodpecker/**.yml",
+        "**/.woodpecker.yml",
+        "**/.woodpecker/**.yaml",
+        "**/.woodpecker.yaml"
+      ],
+      "url": "https://raw.githubusercontent.com/woodpecker-ci/woodpecker/master/pipeline/schema/schema.json"
+    },
+    {
+      "name": "Netin Diagnostic System Template",
+      "description": "Device template schema",
+      "fileMatch": ["*.ndst.yml", "*.ndst.yaml", "*.ndst.json"],
+      "url": "https://s3.eu-central-1.amazonaws.com/files.netin.io/spider-schemas/template.schema.json"
+    },
+    {
+      "description": "YAML Schema for NOODL applications",
+      "fileMatch": ["*.noodl.yml"],
+      "name": "noodl.schema.json",
+      "url": "https://noodl.s3.us-west-1.amazonaws.com/noodl.schema.json"
+    },
+    {
+      "name": "mboats",
+      "description": "Schema for MBOATS Configuration",
+      "fileMatch": ["*.mboats.yaml", "*.mboats.yml"],
+      "url": "https://json.schemastore.org/mboats-config-0.2.json",
+      "versions": {
+        "0.1": "https://json.schemastore.org/mboats-config-0.1.json",
+        "0.2": "https://json.schemastore.org/mboats-config-0.1.json"
+      }
+    },
+    {
+      "name": "StackHawk Scanner Configuration",
+      "description": "Schema for StackHawk Scanner configuration files",
+      "fileMatch": [
+        "stackhawk.yml",
+        "stackhawk.yaml",
+        "stackhawk-*.yml",
+        "stackhawk-*.yaml"
+      ],
+      "url": "https://download.stackhawk.com/hawk/jsonschema/hawkconfig.json"
+    },
+    {
+      "name": "Serverless Framework Configuration",
+      "description": "Schema for serverless framework configuration files",
+      "fileMatch": ["serverless.yml"],
+      "url": "https://raw.githubusercontent.com/lalcebo/json-schema/master/serverless/reference.json"
+    },
+    {
+      "name": "Alacritty Configuration Schema",
+      "description": "Schema for Alacritty configuration yaml file",
+      "fileMatch": [".alacritty.yml", "alacritty.yml"],
+      "url": "https://raw.githubusercontent.com/distinction-dev/alacritty-schema/main/alacritty/reference.json"
+    },
+    {
+      "name": "Serverless Workflow Schema",
+      "description": "Schema for serverless workflows",
+      "fileMatch": ["*.sw.json", "*.sw.yml"],
+      "url": "https://raw.githubusercontent.com/serverlessworkflow/specification/main/schema/workflow.json",
+      "versions": {
+        "v0.8": "https://raw.githubusercontent.com/serverlessworkflow/specification/0.8.x/schema/workflow.json",
+        "v0.7": "https://raw.githubusercontent.com/serverlessworkflow/specification/0.7.x/schema/workflow.json",
+        "v0.6": "https://raw.githubusercontent.com/serverlessworkflow/specification/0.6.x/schema/workflow.json",
+        "v0.5": "https://raw.githubusercontent.com/serverlessworkflow/specification/0.5.x/schema/workflow.json"
+      }
+    },
+    {
+      "name": "Shopware 6 Configuration",
+      "description": "Schema for Shopware 6 custom configurations",
+      "fileMatch": ["shopware.yml", "shopware.yaml"],
+      "url": "https://raw.githubusercontent.com/shopware/platform/trunk/config-schema.json"
+    },
+    {
+      "name": "Shopware CLI Extension Store Configuration",
+      "description": "Schema for Shopware CLI Extension Store Configuration",
+      "fileMatch": [".shopware-extension.yml"],
+      "url": "https://raw.githubusercontent.com/FriendsOfShopware/shopware-cli/main/extension/shopware-extension-schema.json"
+    },
+    {
+      "name": "Shopware CLI Project Store Configuration",
+      "description": "Schema for Shopware CLI Project Store Configuration",
+      "fileMatch": [".shopware-project.yml"],
+      "url": "https://raw.githubusercontent.com/FriendsOfShopware/shopware-cli/main/shop/shopware-project-schema.json"
+    },
+    {
+      "name": "Qodana",
+      "description": "A standard qodana.yaml (or qodana.yml) format for Qodana (https://jetbrains.com/qodana) configuration.",
+      "fileMatch": ["qodana.yaml", "qodana.yml"],
+      "url": "https://json.schemastore.org/qodana-1.0.json"
+    },
+    {
+      "name": "Tye",
+      "description": "Schema for Tye configuration files",
+      "fileMatch": ["tye.yaml", "tye.yml"],
+      "url": "https://raw.githubusercontent.com/dotnet/tye/main/src/schema/tye-schema.json"
+    },
+    {
+      "name": "unist",
+      "description": "Schema for unist syntax trees",
+      "fileMatch": [],
+      "url": "https://json.schemastore.org/unist.json"
+    },
+    {
+      "name": "Hugo",
+      "description": "Hugo static site generator config file schema",
+      "fileMatch": [],
+      "url": "https://json.schemastore.org/hugo.json"
+    },
+    {
+      "name": "Cheatsheets",
+      "description": "Cheatsheets config file schema",
+      "fileMatch": ["conf.yml", "conf.yaml"],
+      "url": "https://json.schemastore.org/cheatsheets.json"
+    },
+    {
+      "name": "deployed-cli",
+      "description": "JSON schema for the deployed cli config file. \n\nSee also: https://hyhello.github.io/deployed\n\n",
+      "fileMatch": [
+        ".deployedrc",
+        ".deployed.json",
+        ".deployed.yaml",
+        ".deployed.yml"
+      ],
+      "url": "https://json.schemastore.org/deployed.json"
+    },
+    {
+      "name": "Xstate Machine Schema",
+      "description": "Schema for making statecharts",
+      "fileMatch": [],
+      "url": "https://raw.githubusercontent.com/statelyai/xstate/main/packages/core/src/machine.schema.json"
+    },
+    {
+      "name": "Butane Config",
+      "description": "Schema to validate butane files for Fedora CoreOS",
+      "fileMatch": ["*.bu"],
+      "url": "https://raw.githubusercontent.com/Relativ-IT/Butane-Schemas/Release/Butane-Schema.json"
+    },
+    {
+      "name": "Updatecli",
+      "description": "Schema for Updatecli manifest",
+      "fileMatch": [
+        "**/updatecli.d/**/*.yaml",
+        "**/updatecli.d/**/*.yml",
+        "updatecli.yml",
+        "updatecli.yaml"
+      ],
+      "url": "https://www.updatecli.io/schema/latest/config.json"
+    },
+    {
+      "name": "GeoJSON.json latest",
+      "description": "GeoJSON format for representing geographic data. Newest version from GeoJSON org.",
+      "url": "https://geojson.org/schema/GeoJSON.json"
+    },
+    {
+      "name": ".clang-format",
+      "description": "yaml schema for clang-format config",
+      "fileMatch": [".clang-format"],
+      "url": "https://json.schemastore.org/clang-format.json"
+    },
+    {
+      "name": "Estuary Flow Catalog Schema",
+      "description": "JSON schema for Flow catalog files. See: https://github.com/estuary/flow",
+      "fileMatch": ["flow.yaml", "*.flow.yaml", "flow.json", "*.flow.json"],
+      "url": "https://raw.githubusercontent.com/estuary/flow/master/flow.schema.json"
+    },
+    {
+      "name": "V2Ray",
+      "description": "JSON schema for V2Ray jsonv4/jsonv5 configuration format",
+      "fileMatch": ["**/v2ray/*.json"],
+      "url": "https://raw.githubusercontent.com/EHfive/v2ray-jsonschema/main/v4-config.schema.json",
+      "versions": {
+        "jsonv4": "https://raw.githubusercontent.com/EHfive/v2ray-jsonschema/main/v4-config.schema.json",
+        "jsonv5-preview": "https://raw.githubusercontent.com/EHfive/v2ray-jsonschema/main/v5-config.schema.json"
+      }
+    },
+    {
+      "name": "GherKing",
+      "description": "GherKing configuration",
+      "fileMatch": [
+        ".gherking.json",
+        ".gherkingrc",
+        ".gherking.js",
+        "gherking.json",
+        "gherking.js"
+      ],
+      "url": "https://raw.githubusercontent.com/gherking/gherking/master/schema/gherking.schema.json"
+    },
+    {
+      "name": "CICS TS region tagging",
+      "description": "JSON schema for CICS region tagging in IBM CICS Transaction Server for z/OS",
+      "fileMatch": ["cicstags.yaml"],
+      "url": "https://public.dhe.ibm.com/ibmdl/export/pub/software/htp/cics/schemas/json/cicstags.json"
+    },
+    {
+      "name": "CICS TS resource import",
+      "description": "JSON schema for resource import in IBM CICS Transaction Server for z/OS",
+      "fileMatch": ["*.cicsresourceimport.yaml", "*.cicsresourceimport.yml"],
+      "url": "https://public.dhe.ibm.com/ibmdl/export/pub/software/htp/cics/schemas/json/cicsts-resourceimport.json"
+    },
+    {
+      "name": "CICS TS resource model",
+      "description": "JSON schema for resource model in IBM CICS Transaction Server for z/OS",
+      "fileMatch": [
+        "*.cicsresourcemodel.yaml",
+        "*.cicsresourcemodel.yml",
+        "*.cicsappconstraints.yaml",
+        "*.cicsappconstraints.yml"
+      ],
+      "url": "https://public.dhe.ibm.com/ibmdl/export/pub/software/htp/cics/schemas/json/cicsts-resourcemodel.json"
+    },
+    {
+      "name": "CICS TS resource overrides",
+      "description": "JSON schema for resource overrides in IBM CICS Transaction Server for z/OS",
+      "fileMatch": [
+        "**/resourceoverrides/*.yaml",
+        "**/resourceoverrides/*.yml",
+        "*.cicsoverrides.yaml",
+        "*.cicsoverrides.yml"
+      ],
+      "url": "https://public.dhe.ibm.com/ibmdl/export/pub/software/htp/cics/schemas/json/resourceoverrides.json"
+    },
+    {
+      "name": "Webman package recipe",
+      "description": "YAML schema for a webman package",
+      "fileMatch": ["*.webman-pkg.yml"],
+      "url": "https://raw.githubusercontent.com/candrewlee14/webman/main/schema/pkg_schema.json"
+    },
+    {
+      "name": "webhint.io",
+      "description": "A configuration file for hint",
+      "fileMatch": [".hintrc"],
+      "url": "https://raw.githubusercontent.com/webhintio/hint/main/packages/hint/src/lib/config/config-schema.json"
+    },
+    {
+      "name": "AVA Configuration Schema",
+      "description": "Schema for configuring AVA, the Node.js test runner",
+      "fileMatch": ["ava.config.json"],
+      "url": "https://json.schemastore.org/ava.json"
+    },
+    {
+      "name": "Datahub Ingestion Recipe Schema",
+      "description": "Schema for Datahub Ingestion recipe. \n\nSee also at https://datahubproject.io/docs/metadata-ingestion\n\n",
+      "fileMatch": ["*.dhub.yml", "*.dhub.yaml", "*.dhub.json"],
+      "url": "https://datahubproject.io/schemas/datahub_ingestion_schema.json"
+    },
+    {
+      "name": "Quali Torque Blueprint Spec 2",
+      "description": "Schema for Torque bluerpint",
+      "fileMatch": ["**/blueprints/**.yaml"],
+      "url": "https://raw.githubusercontent.com/QualiTorque/torque-vs-code-extensions/master/client/schemas/blueprint-spec2-schema.json"
+    },
+    {
+      "name": "jscpd Configuration Schema",
+      "description": "Copy/paste detector for programming source code",
+      "fileMatch": [".jscpd.json"],
+      "url": "https://json.schemastore.org/jscpd.json"
+    },
+    {
+      "name": "Pterodactyl",
+      "description": "Schema for Pterodactyl, a free game server control panel",
+      "fileMatch": ["egg-*.json"],
+      "url": "https://json.schemastore.org/pterodactyl.json"
+    },
+    {
+      "name": "Hardware Sentry Configuration",
+      "description": "Hardware Sentry configuration file",
+      "fileMatch": ["*hws-config*.yaml", "*hws-config*.yml"],
+      "url": "https://json.schemastore.org/hws-config.json"
+    },
+    {
+      "name": "devspace.yaml",
+      "description": "yaml schema for devspace.yaml",
+      "fileMatch": ["devspace.yaml"],
+      "url": "https://raw.githubusercontent.com/loft-sh/devspace/main/devspace-schema.json"
+    },
+    {
+      "name": "Monika Configuration Schema",
+      "description": "Monika configuration schema file",
+      "fileMatch": ["*monika*.yaml", "*monika*.yml", "monika.json"],
+      "url": "https://json.schemastore.org/monika-config-schema.json"
+    },
+    {
+      "name": "Istanbul Schema",
+      "description": "Schema for Istanbul, a JavaScript code coverage tool",
+      "fileMatch": [".nycrc", ".nycrc.json", ".nycrc.yaml", ".nycrc.yml"],
+      "url": "https://json.schemastore.org/nycrc.json"
+    },
+    {
+      "name": "MongoDB Atlas Search Index Definition Schema",
+      "description": "Schema for MongoDB Atlas Search index",
+      "fileMatch": ["*-index.json"],
+      "url": "https://json.schemastore.org/mongodb-atlas-search-index-definition.json"
+    },
+    {
+      "name": "KoDE/CI build.yaml",
+      "description": "yaml schema for kode/ci build",
+      "fileMatch": ["**/.kode/*.yaml"],
+      "url": "https://json.schemastore.org/kode-ci-build-1.0.0.json"
+    },
+    {
+      "name": "Kong DBLess Schema",
+      "description": "yaml schema dbless configuration",
+      "fileMatch": ["kong.yaml", "kong.yml"],
+      "url": "https://json.schemastore.org/kong_json_schema.json"
+    },
+    {
+      "name": "Embrace Config Schema",
+      "description": "JSON Schema definition for the Embrace configuration file",
+      "fileMatch": ["embrace-config.json"],
+      "url": "https://json.schemastore.org/embrace-config-schema-1.0.0.json"
+    },
+    {
+      "name": "petstore-v1.0",
+      "description": "petstore yaml validation",
+      "fileMatch": ["petstore-v1.0.json"],
+      "url": "https://json.schemastore.org/petstore-v1.0.json",
+      "versions": {
+        "1.0": "https://json.schemastore.org/petstore-v1.0.json"
+      }
+    },
+    {
+      "name": "JFrog Pipelines YML DSL",
+      "description": "Schema for JFrog Pipelines YML based DSL schema definition",
+      "fileMatch": [
+        "**/.jfrog-pipelines/**/*.yml",
+        "**/.jfrog-pipelines/**/*.yaml"
+      ],
+      "url": "https://json.schemastore.org/jfrog-pipelines.json"
+    },
+    {
+      "name": "StrmPrivacy batch job configuration file",
+      "description": "StrmPrivacy batch job\nhttps://docs.strmprivacy.io/docs/latest/concepts/data-processing/batch-jobs/",
+      "fileMatch": ["*batch-job-config*.json", "*batch-job-config*.yaml"],
+      "url": "https://json-schema.api.strmprivacy.io/latest/strmprivacy.api.entities.v1.BatchJob.json",
+      "versions": {
+        "1.0": "https://json-schema.api.strmprivacy.io/latest/strmprivacy.api.entities.v1.BatchJob.json"
+      }
+    },
+    {
+      "name": "StrmPrivacy SimpleSchema",
+      "description": "StrmPrivacy SimpleSchema\nhttps://docs.strmprivacy.io/docs/latest/quickstart/data-contracts/simple-schema/",
+      "fileMatch": ["*simple-schema*.json", "*simple-schema*.yaml"],
+      "url": "https://json-schema.api.strmprivacy.io/latest/strmprivacy.api.entities.v1.Schema.SimpleSchemaDefinition.json",
+      "versions": {
+        "1.0": "https://json-schema.api.strmprivacy.io/latest/strmprivacy.api.entities.v1.Schema.SimpleSchemaDefinition.json"
+      }
+    },
+    {
+      "name": "StrmPrivacy Stream",
+      "description": "StrmPrivacy Stream\nhttps://docs.strmprivacy.io/docs/latest/quickstart/streaming/creating-streams/",
+      "fileMatch": ["*stream.json", "*stream.yaml"],
+      "url": "https://json-schema.api.strmprivacy.io/latest/strmprivacy.api.entities.v1.Stream.json",
+      "versions": {
+        "1.0": "https://json-schema.api.strmprivacy.io/latest/strmprivacy.api.entities.v1.Stream.json"
+      }
+    },
+    {
+      "name": "StrmPrivacy Data Connector",
+      "description": "StrmPrivacy Data Connector\nhttps://docs.strmprivacy.io/docs/latest/concepts/data-connectors/",
+      "fileMatch": ["*data-connector.json", "*data-connector.yaml"],
+      "url": "https://json-schema.api.strmprivacy.io/latest/strmprivacy.api.entities.v1.DataConnector.json",
+      "versions": {
+        "1.0": "https://json-schema.api.strmprivacy.io/latest/strmprivacy.api.entities.v1.DataConnector.json"
+      }
+    },
+    {
+      "name": "StrmPrivacy Data Contract",
+      "description": "StrmPrivacy Data Contract\nhttps://docs.strmprivacy.io/docs/latest/concepts/data-contracts/",
+      "fileMatch": ["*contract.json", "*contract.yaml"],
+      "url": "https://json-schema.api.strmprivacy.io/latest/strmprivacy.api.entities.v1.DataContract.json",
+      "versions": {
+        "1.0": "https://json-schema.api.strmprivacy.io/latest/strmprivacy.api.entities.v1.DataContract.json"
+      }
+    },
+    {
+      "name": "Keycloak REST API",
+      "description": "REST API schema for Keycloak Admin",
+      "url": "https://raw.githubusercontent.com/dahag-ag/keycloak-openapi/main/OpenApiDefinitions/keycloak-19.0.0.json",
+      "versions": {
+        "16.0": "https://raw.githubusercontent.com/dahag-ag/keycloak-openapi/main/OpenApiDefinitions/keycloak-16.0.json",
+        "17.0.1": "https://raw.githubusercontent.com/dahag-ag/keycloak-openapi/main/OpenApiDefinitions/keycloak-17.0.1.json",
+        "18.0.0": "https://raw.githubusercontent.com/dahag-ag/keycloak-openapi/main/OpenApiDefinitions/keycloak-18.0.0.json",
+        "19.0.0": "https://raw.githubusercontent.com/dahag-ag/keycloak-openapi/main/OpenApiDefinitions/keycloak-19.0.0.json"
+      }
+    },
+    {
+      "name": "ize.toml",
+      "description": "TOML Schema ❯ize Infra Tool",
+      "fileMatch": ["ize.toml"],
+      "url": "https://raw.githubusercontent.com/hazelops/ize/1.1.5/internal/schema/ize-spec.json",
+      "versions": {
+        "1.1.5": "https://raw.githubusercontent.com/hazelops/ize/1.1.5/internal/schema/ize-spec.json",
+        "1.1.4": "https://raw.githubusercontent.com/hazelops/ize/1.1.4/internal/schema/ize-spec.json"
+      }
+    },
+    {
+      "name": "Uplift",
+      "description": "Uplift configuration file",
+      "fileMatch": [".uplift.yml", ".uplift.yaml", "uplift.yml", "uplift.yaml"],
+      "url": "https://upliftci.dev/static/schema.json"
+    },
+    {
+      "name": "QueryFirst config file",
+      "description": "Config options for QueryFirst, SQL wrapper generator.",
+      "fileMatch": ["qfconfig.json"],
+      "url": "https://json.schemastore.org/qfconfig.json",
+      "versions": {
+        "1.0": "https://json.schemastore.org/qfconfig.json"
+      }
+    },
+    {
+      "name": "Unreal Engine Uplugin",
+      "description": "Unreal Engine plugin configuration file",
+      "fileMatch": [".uplugin"],
+      "url": "https://json.schemastore.org/uplugin.json"
+    },
+    {
+      "name": "Unreal Engine Uproject",
+      "description": "Unreal Engine project configuration file",
+      "fileMatch": [".uproject"],
+      "url": "https://json.schemastore.org/uproject.json"
+    }
+  ],
+  "version": 1
+}


### PR DESCRIPTION
XmlElementHasUnsatisfiedCondition is effectively the same code that was inside SanitizeProjectNode's `"ItemGroup"` handler which was already evaluating conditions in its child nodes. This new helper is now used for ItemGroup, but also the handler for ItemDefinitionGroup, so that child ClCompile/Link/Lib/etc nodes will have their properties evaluated and skip calls to `Set-ProjectItemProperty` if the conditions are false.

When I applied these changes locally, it resolved my issues.