### PR TITLE
Fix #1227 Get-ProjectStdafxDir not correctly handling PCH paths

### DIFF
--- a/ClangPowerTools/ClangPowerToolsShared/Tooling/v1/psClang/msbuild-project-data.ps1
+++ b/ClangPowerTools/ClangPowerToolsShared/Tooling/v1/psClang/msbuild-project-data.ps1
@@ -153,10 +153,10 @@ Function Get-Project-SDKVer()
     }
 
     if ([string]::IsNullOrEmpty($WindowsTargetPlatformVersion))
-    { 
-        return "" 
-    } 
-    
+    {
+        return ""
+    }
+
     return $WindowsTargetPlatformVersion.Trim()
 }
 
@@ -379,9 +379,9 @@ Function Get-ProjectIncludeDirectories()
     {
         return @(Get-ProjectIncludesFromIncludePathVar)
     }
-    else 
+    else
     {
-        $returnArray += @(Get-ProjectIncludesFromIncludePathVar)    
+        $returnArray += @(Get-ProjectIncludesFromIncludePathVar)
     }
 
     return ( $returnArray | ForEach-Object { Remove-PathTrailingSlash -path $_ } )
@@ -499,9 +499,10 @@ Function Get-ProjectStdafxDir( [Parameter(Mandatory = $true)]  [string]   $pchHe
 
         foreach ($dir in $searchPool)
         {
-            [string] $stdafxPath = Canonize-Path -base $dir -child $pchHeaderName -ignoreErrors
-            if (![string]::IsNullOrEmpty($stdafxPath))
+            [string] $stdafxPathTest = Canonize-Path -base $dir -child $pchHeaderName -ignoreErrors
+            if (![string]::IsNullOrEmpty($stdafxPathTest))
             {
+                $stdafxPath = $stdafxPathTest
                 break
             }
         }
@@ -510,6 +511,14 @@ Function Get-ProjectStdafxDir( [Parameter(Mandatory = $true)]  [string]   $pchHe
     if ([string]::IsNullOrEmpty($stdafxPath))
     {
         return ""
+    }
+    # This elseif will handle cases like where the PCH header is more than just a filename, but includes a parent directory as well.
+    # E.g. <PrecompiledHeaderFile>$(ProjectName)\$(ProjectName)_headers.h</PrecompiledHeaderFile>
+    # See this issue for more details https://github.com/Caphyon/clang-power-tools/issues/1227
+    elseif ($stdafxPath.EndsWith($pchHeaderName))
+    {
+        [string] $stdafxDir = $stdafxPath.Remove($stdafxPath.Length - $pchHeaderName.Length, $pchHeaderName.Length)
+        return $stdafxDir
     }
     else
     {


### PR DESCRIPTION
Before these changes, the following CPT output was hit due to the final else behavior of calling `Get-FileDirectory`
```
PCH cpp name: D:\source\core\corelib\corelib_headers.cpp
PCH header name: corelib\corelib_headers.h
PCH directory: D:\source\core\corelib\
Generating PCH...
Join-Path : Cannot find path 'D:\source\core\corelib\corelib\corelib_headers.h'
```

With settings like
```xml
<PrecompiledHeaderFile>$(ProjectName)\$(ProjectName)_headers.h</PrecompiledHeaderFile>
<ForcedIncludeFiles>$(ProjectName)\$(ProjectName)_headers.h;%(ForcedIncludeFiles)</ForcedIncludeFiles>
```