### PR TITLE
Add better handling for retrieving error while Clang commands are run…

### DIFF
--- a/ClangPowerTools/ClangPowerToolsShared/Commands/ClangCommand.cs
+++ b/ClangPowerTools/ClangPowerToolsShared/Commands/ClangCommand.cs
@@ -244,7 +244,7 @@ namespace ClangPowerTools
         GenerateDocumentation.OutputDir = documentationOutoutePath;
         CommandControllerInstance.CommandController.DisplayMessage(false, "Please wait ...");
         string Script = $"-ExecutionPolicy Unrestricted -NoProfile -Noninteractive -command \"& " +
-        $"'{clangDocPath}' --public {projectArguments} --format={GenerateDocumentation.Formats[commandId]}  -output='{documentationOutoutePath}' '{jsonCompilationDatabasePath}' \" 2>&1 | Out-Null ";
+        $"''{clangDocPath}'' --public {projectArguments} --format={GenerateDocumentation.Formats[commandId]}  -output=''{documentationOutoutePath}'' ''{jsonCompilationDatabasePath}'''";
 
         PowerShellWrapper.Invoke(Script);
 

--- a/ClangPowerTools/ClangPowerToolsShared/Commands/ClangCommand.cs
+++ b/ClangPowerTools/ClangPowerToolsShared/Commands/ClangCommand.cs
@@ -244,7 +244,8 @@ namespace ClangPowerTools
         GenerateDocumentation.OutputDir = documentationOutoutePath;
         CommandControllerInstance.CommandController.DisplayMessage(false, "Please wait ...");
         string Script = $"-ExecutionPolicy Unrestricted -NoProfile -Noninteractive -command \"& " +
-        $"''{clangDocPath}'' --public {projectArguments} --format={GenerateDocumentation.Formats[commandId]}  -output=''{documentationOutoutePath}'' ''{jsonCompilationDatabasePath}'''";
+        $"'{clangDocPath}' --public {projectArguments} --format={GenerateDocumentation.Formats[commandId]}  " +
+        $"-output='{documentationOutoutePath}' '{jsonCompilationDatabasePath}' \"";
 
         PowerShellWrapper.Invoke(Script);
 

--- a/ClangPowerTools/ClangPowerToolsShared/Output/OutputProcessor.cs
+++ b/ClangPowerTools/ClangPowerToolsShared/Output/OutputProcessor.cs
@@ -91,8 +91,11 @@ namespace ClangPowerTools.Output
 
       while (mErrorDetector.Detect(aText, parser, out Match aMatchResult))
       {
-        aDetectedErrors.Add(GetDetectedError(aHierarchy, aMatchResult));
-        aOutputBuilder.Append(GetOutput(ref aText, aDetectedErrors.Last().FullMessage));
+        var detectedError = GetDetectedError(aHierarchy, aMatchResult);
+        if (detectedError != null)
+          aDetectedErrors.Add(detectedError);
+
+        aOutputBuilder.Append(GetOutput(ref aText, aDetectedErrors.Count == 0 ? "" : aDetectedErrors.Last().FullMessage));
       }
       aOutputText = aOutputBuilder.ToString();
     }


### PR DESCRIPTION
…ning

As a side effect, the clang-doc log now is shown progressively as it occurs, since we no longer suppress the log using Out-Null.
I accidentally closed #1131

fixes #1129