### PR TITLE
Clang-Tidy ignores <ExternalIncludePath> dependencies

### DIFF
--- a/ClangPowerTools/ClangPowerToolsShared/Tooling/v1/clang-build.ps1
+++ b/ClangPowerTools/ClangPowerToolsShared/Tooling/v1/clang-build.ps1
@@ -1284,8 +1284,10 @@ Function Process-Project( [Parameter(Mandatory=$true)] [string]       $vcxprojPa
     #-----------------------------------------------------------------------------------------------
     # DETECT PROJECT ADDITIONAL INCLUDE DIRECTORIES AND CONSTRUCT INCLUDE PATHS
 
-    [string[]] $global:additionalIncludeDirectories = @(Get-ProjectExternalIncludePath)
-    $additionalIncludeDirectories += @(Get-ProjectAdditionalIncludes)
+    [string[]] $global:additionalIncludeDirectories = @(Get-ProjectAdditionalIncludes)
+    # We use the same mechanism for injecting external include paths
+    $additionalIncludeDirectories += @(Get-ProjectExternalIncludePath)
+    
     Write-Verbose-Array -array $additionalIncludeDirectories -name "Additional include directories"
     Add-ToProjectSpecificVariables 'additionalIncludeDirectories'
 

--- a/ClangPowerTools/ClangPowerToolsShared/Tooling/v1/clang-build.ps1
+++ b/ClangPowerTools/ClangPowerToolsShared/Tooling/v1/clang-build.ps1
@@ -1284,7 +1284,8 @@ Function Process-Project( [Parameter(Mandatory=$true)] [string]       $vcxprojPa
     #-----------------------------------------------------------------------------------------------
     # DETECT PROJECT ADDITIONAL INCLUDE DIRECTORIES AND CONSTRUCT INCLUDE PATHS
 
-    [string[]] $global:additionalIncludeDirectories = @(Get-ProjectAdditionalIncludes)
+    [string[]] $global:additionalIncludeDirectories = @(Get-ProjectExternalIncludePath)
+    $additionalIncludeDirectories += @(Get-ProjectAdditionalIncludes)
     Write-Verbose-Array -array $additionalIncludeDirectories -name "Additional include directories"
     Add-ToProjectSpecificVariables 'additionalIncludeDirectories'
 

--- a/ClangPowerTools/ClangPowerToolsShared/Tooling/v1/psClang/msbuild-project-data.ps1
+++ b/ClangPowerTools/ClangPowerToolsShared/Tooling/v1/psClang/msbuild-project-data.ps1
@@ -433,6 +433,10 @@ Function Get-ProjectPreprocessorDefines()
 
 Function Get-ProjectExternalIncludePath()
 {
+	if (! (Test-Path -Path "Variable:\ExternalIncludePath")) {
+		return
+    }
+	
     $data = $ExternalIncludePath;
 
     [string[]] $tokens = @($data -split ";")

--- a/ClangPowerTools/ClangPowerToolsShared/Tooling/v1/psClang/msbuild-project-data.ps1
+++ b/ClangPowerTools/ClangPowerToolsShared/Tooling/v1/psClang/msbuild-project-data.ps1
@@ -431,14 +431,9 @@ Function Get-ProjectPreprocessorDefines()
     return $defines
 }
 
-Function Get-ProjectExternalIncludePath()
-{
-	if (! (Test-Path -Path "Variable:\ExternalIncludePath")) {
-		return
-    }
-	
-    $data = $ExternalIncludePath;
 
+Function Get-PathsFromElementContent([Parameter(Mandatory = $true)]  [string]   $data)
+{
     [string[]] $tokens = @($data -split ";")
 
     foreach ($token in $tokens)
@@ -456,26 +451,20 @@ Function Get-ProjectExternalIncludePath()
     }
 }
 
+Function Get-ProjectExternalIncludePath()
+{
+	if (! (Test-Path -Path "Variable:\ExternalIncludePath")) {
+       return
+    }
+    $data = $ExternalIncludePath;
+    Get-PathsFromElementContent -data $data
+}
+
 Function Get-ProjectAdditionalIncludes()
 {
     Set-ProjectItemContext "ClCompile"
     $data = Get-ProjectItemProperty "AdditionalIncludeDirectories"
-
-    [string[]] $tokens = @($data -split ";")
-
-    foreach ($token in $tokens)
-    {
-        if ([string]::IsNullOrWhiteSpace($token))
-        {
-            continue
-        }
-
-        [string] $includePath = Canonize-Path -base $ProjectDir -child $token.Trim() -ignoreErrors
-        if (![string]::IsNullOrEmpty($includePath))
-        {
-            $includePath -replace '\\$', ''
-        }
-    }
+    Get-PathsFromElementContent -data $data
 }
 
 Function Get-ProjectForceIncludes()

--- a/ClangPowerTools/ClangPowerToolsShared/Tooling/v1/psClang/msbuild-project-data.ps1
+++ b/ClangPowerTools/ClangPowerToolsShared/Tooling/v1/psClang/msbuild-project-data.ps1
@@ -432,9 +432,9 @@ Function Get-ProjectPreprocessorDefines()
 }
 
 
-Function Get-PathsFromElementContent([Parameter(Mandatory = $true)]  [string]   $data)
+Function Get-ProjCanonizedPaths([Parameter(Mandatory = $true)][string] $rawPaths)
 {
-    [string[]] $tokens = @($data -split ";")
+    [string[]] $tokens = @($rawPaths -split ";")
 
     foreach ($token in $tokens)
     {
@@ -451,20 +451,24 @@ Function Get-PathsFromElementContent([Parameter(Mandatory = $true)]  [string]   
     }
 }
 
-Function Get-ProjectExternalIncludePath()
+Function Get-ProjectExternalIncludePaths()
 {
-	if (! (Test-Path -Path "Variable:\ExternalIncludePath")) {
-       return
+    if (!(VariableExistsAndNotEmpty -name "ExternalIncludePath"))
+    {
+       return @()
     }
-    $data = $ExternalIncludePath;
-    Get-PathsFromElementContent -data $data
+    return Get-ProjCanonizedPaths -rawPaths $ExternalIncludePath
 }
 
 Function Get-ProjectAdditionalIncludes()
 {
     Set-ProjectItemContext "ClCompile"
     $data = Get-ProjectItemProperty "AdditionalIncludeDirectories"
-    Get-PathsFromElementContent -data $data
+    if (!(VariableExistsAndNotEmpty -name "data"))
+    {
+        return @()
+    }
+    return Get-ProjCanonizedPaths -rawPaths $data
 }
 
 Function Get-ProjectForceIncludes()

--- a/ClangPowerTools/ClangPowerToolsShared/Tooling/v1/psClang/msbuild-project-data.ps1
+++ b/ClangPowerTools/ClangPowerToolsShared/Tooling/v1/psClang/msbuild-project-data.ps1
@@ -431,6 +431,27 @@ Function Get-ProjectPreprocessorDefines()
     return $defines
 }
 
+Function Get-ProjectExternalIncludePath()
+{
+    $data = $ExternalIncludePath;
+
+    [string[]] $tokens = @($data -split ";")
+
+    foreach ($token in $tokens)
+    {
+        if ([string]::IsNullOrWhiteSpace($token))
+        {
+            continue
+        }
+
+        [string] $includePath = Canonize-Path -base $ProjectDir -child $token.Trim() -ignoreErrors
+        if (![string]::IsNullOrEmpty($includePath))
+        {
+            $includePath -replace '\\$', ''
+        }
+    }
+}
+
 Function Get-ProjectAdditionalIncludes()
 {
     Set-ProjectItemContext "ClCompile"


### PR DESCRIPTION
#1224 