### PR TITLE
Bugfix: When .clang-tidy file isn't found, use checks are set to predifinedChecks.

### DIFF
--- a/ClangPowerTools/ClangPowerToolsShared/Commands/TidyCommand.cs
+++ b/ClangPowerTools/ClangPowerToolsShared/Commands/TidyCommand.cs
@@ -152,15 +152,12 @@ namespace ClangPowerTools.Commands
 
               if (tidySettings.DetectClangTidyFile && !mItemsCollector.IsEmpty)
               {
-                // Check for .clang-tidy config file
-                if (FileSystem.SearchAllTopDirectories(mItemsCollector.Items[0].GetPath(), FileSystem.ConfigClangTidyFileName))
-                  tidySettings.UseChecksFrom = ClangTidyUseChecksFrom.TidyFile;
-                else
-                  tidySettings.UseChecksFrom = ClangTidyUseChecksFrom.PredefinedChecks;
+                tidySettings.UseChecksFrom = ClangTidyUseChecksFrom.TidyFile;
 
                 var settingsHandlder = new SettingsHandler();
                 settingsHandlder.SaveSettings();
               }
+
               if (CommandIds.kTidyToolWindowId == aCommandId)
                 RunScript(CommandIds.kTidyId, false, paths);
               else

--- a/ClangPowerTools/ClangPowerToolsShared/Helpers/FileSystem.cs
+++ b/ClangPowerTools/ClangPowerToolsShared/Helpers/FileSystem.cs
@@ -22,23 +22,6 @@ namespace ClangPowerTools.Helpers
 
     #region Methods
 
-    public static bool SearchAllTopDirectories(string filePath, string searchedFileName)
-    {
-      while (string.IsNullOrEmpty(filePath) == false)
-      {
-        if (DoesFileExist(filePath, searchedFileName))
-          return true;
-
-        var index = filePath.LastIndexOf("\\");
-        if (index > 0)
-          filePath = filePath.Remove(index);
-        else
-          return false;
-      }
-
-      return false;
-    }
-
     public static bool SearchAllTopDirectories(string filePath, IEnumerable<string> searchedFiles)
     {
       while (string.IsNullOrEmpty(filePath) == false)


### PR DESCRIPTION
#1271