### PR TITLE
Get-ChildItem long prefix path doesn't work with PowerShell 5.0.

### DIFF
--- a/ClangPowerTools/ClangPowerToolsShared/Tooling/v1/clang-build.ps1
+++ b/ClangPowerTools/ClangPowerToolsShared/Tooling/v1/clang-build.ps1
@@ -550,14 +550,18 @@ function Load-Solutions()
 {
    Write-Verbose "Scanning for solution files"
    [string] $pathToCheck = $aSolutionsPath
-   if ($kPsMajorVersion -lt 6)
+   Try
    {
-     # we need not bother with long path support in PowerShell 6+
-     # only in Windows PowerShell
+     # no need of long path prefix for Powershell > 5.0
+     $slns = Get-ChildItem -recurse -LiteralPath $pathToCheck -Filter "*$kExtensionSolution"
+   }
+   Catch
+   {
+     # use long path prefix for PowerShell <= 5.0
      $pathToCheck = "\\?\$aSolutionsPath"
+     $slns = Get-ChildItem -recurse -LiteralPath $pathToCheck -Filter "*$kExtensionSolution"
    }
 
-   $slns = Get-ChildItem -recurse -LiteralPath $pathToCheck -Filter "*$kExtensionSolution"
    foreach ($sln in $slns)
    {
      Write-Verbose "Caching solution file $sln"

--- a/ClangPowerTools/ClangPowerToolsShared/Tooling/v1/psClang/msbuild-project-load.ps1
+++ b/ClangPowerTools/ClangPowerToolsShared/Tooling/v1/psClang/msbuild-project-load.ps1
@@ -436,7 +436,16 @@ function Detect-ProjectDefaultConfigPlatform()
     Set-Var -Name "Platform"            -Value $configAndPlatform[1]
     # manually set PlatformTarget for vcpkg
     # note that $(PlatformTarget) is not available at the top of the .vcxproj file.
-    Set-Var -Name "PlatformTarget"      -Value $configAndPlatform[1]
+    if($configAndPlatform[1] -eq "Win32")
+    {
+        # solution platforms use 'x86' and 'x64', not Win32
+        # set PlatformTarget to 'x86' to build the correct path for vcpkg lib
+        Set-Var -Name "PlatformTarget"  -Value "x86"
+    }
+    else
+    {
+        Set-Var -Name "PlatformTarget"  -Value $configAndPlatform[1]
+    }
 }
 
 function NodeHasUnsatisfiedCondition([System.Xml.XmlNode] $node)


### PR DESCRIPTION
#1315 
#1115