### PR TITLE
Wrong path detected after running tidy

### DIFF
--- a/ClangPowerTools/ClangPowerToolsShared/Error/ErrorParserConstants.cs
+++ b/ClangPowerTools/ClangPowerToolsShared/Error/ErrorParserConstants.cs
@@ -13,7 +13,7 @@
     public const string kMessageTag = "message";
     public const string kErrorMessageRegex = @"(.\:(\\|\/)[ \S+\\\/.]*[c|C|h|H|cpp|CPP|cc|CC|cxx|CXX|c++|C++|cp|CP])(\r\n|\r|\n| |:)*(\d+)(\r\n|\r|\n| |:)*(\d+)(\r\n|\r|\n| |:)*(error|note|warning)[^s](\r\n|\r|\n| |:)*(.*)";
     public const string kMatchMessageRegex = @"<([A-Z]:.+?\.(cpp|cu|cc|cp|tlh|c|cxx|tli|h|hh|hpp|hxx)):(\d+):(\d+),\s(?:col:\d+|line:\d+:\d+)>";
-    public const string kMatchTidyFileRegex = @"([A-Z]:\\.[^""]+?\.(cpp|cu|cc|cp|tlh|c|cxx|tli|h|hh|hpp|hxx))(\W|$)";
+    public const string kMatchTidyFileRegex = @"^(?!.*and children =).*([A-Z]:\\.[^""]+?\.(cpp|cu|cc|cp|tlh|c|cxx|tli|h|hh|hpp|hxx))(\W|$)";
     public const string kNumberMatchesRegex = @"(\d+)\s(matches|match)\.";
     public const string kJsonCompilationDbFilePathRegex = @"Exported JSON Compilation Database to (.+\.json)";
 


### PR DESCRIPTION
Use negative lookahead to ignore paths detected in output that contains "and children =".
#1322