### PR TITLE
1072 support running tidy with compilation db

### DIFF
--- a/ClangPowerTools/ClangPowerToolsShared/MVVM/Models/TidySettingsModel.cs
+++ b/ClangPowerTools/ClangPowerToolsShared/MVVM/Models/TidySettingsModel.cs
@@ -11,7 +11,7 @@
     public string CustomChecks { get; set; } = string.Empty;
 
     public string CustomExecutable { get; set; } = string.Empty;
-
+    public string CompilationDatabaseDir { get; set; } = string.Empty;
     public bool DetectClangTidyFile { get; set; } = true;
 
     public bool FormatAfterTidy { get; set; } = false;

--- a/ClangPowerTools/ClangPowerToolsShared/MVVM/SettingsTooltips.cs
+++ b/ClangPowerTools/ClangPowerToolsShared/MVVM/SettingsTooltips.cs
@@ -30,6 +30,7 @@
     public string PredefinedChecks { get; } = "A list of clang-tidy static analyzer and diagnostics checks from LLVM.";
     public string CustomChecks { get; } = "Specify clang-tidy checks to run using the standard tidy syntax. You can use wildcards to match multiple checks, combine them, etc (Eg. \"modernize-*, readability-*\").";
     public string CustomExecutableTidy { get; } = "Specify a custom path for \"clang-tidy.exe\" file to run instead of the built-in one (v8.0).";
+    public string CompilationDatabaseDir{ get; } = "Specify a custom path for directory where \"compile_commands.json\" file is located to use it as a source of compilation flags instead of passing them through command line.";
     public string DetectClangTidyFile { get; } = "Automatically detect the \".clang-tidy\" file and set the \"Use checks from\" option to \"TidyFile\" if the file exists. Otherwise, set the \"Use checks from\" option to \"PredefinedChecks\".";
     public string FormatAfterTidy { get; } = "Automatically run clang-format after clang-tidy finished.";
     public string TidyOnSave { get; } = "Automatically run clang-tidy when saving the current source file.";

--- a/ClangPowerTools/ClangPowerToolsShared/MVVM/ViewModels/TidySettingsViewModel.cs
+++ b/ClangPowerTools/ClangPowerToolsShared/MVVM/ViewModels/TidySettingsViewModel.cs
@@ -21,6 +21,7 @@ namespace ClangPowerTools
     private string displayWarning = string.Empty;
     private ICommand headerFilterAddDataCommand;
     private ICommand customExecutableBrowseCommand;
+    private ICommand compilationDatabaseDirBrowseCommand;
     private ICommand predefinedChecksSelectCommand;
     private ICommand customChecksAddDataCommand;
     private ICommand exportTidyConfigCommand;
@@ -118,6 +119,11 @@ namespace ClangPowerTools
       get => customExecutableBrowseCommand ?? (customExecutableBrowseCommand = new RelayCommand(() => UpdateCustomExecutable(), () => CanExecute));
     }
 
+    public ICommand CompilationDatabaseDirBrowseCommand
+        {
+      get => compilationDatabaseDirBrowseCommand ?? (compilationDatabaseDirBrowseCommand = new RelayCommand(() => UpdateCompilationDatabaseDir(), () => CanExecute));
+    }
+
     public ICommand PredefinedChecksSelectCommand
     {
       get => predefinedChecksSelectCommand ?? (predefinedChecksSelectCommand = new RelayCommand(() => UpdatePredefinedChecks(), () => CanExecute));
@@ -164,6 +170,12 @@ namespace ClangPowerTools
     private void UpdateCustomExecutable()
     {
       tidyModel.CustomExecutable = OpenFile(string.Empty, ".exe", "Executable files|*.exe");
+      PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("TidyModel"));
+    }
+
+    private void UpdateCompilationDatabaseDir()
+    {
+      tidyModel.CompilationDatabaseDir = BrowseForFolderFiles();
       PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("TidyModel"));
     }
 

--- a/ClangPowerTools/ClangPowerToolsShared/MVVM/Views/TidySettingsView.xaml
+++ b/ClangPowerTools/ClangPowerToolsShared/MVVM/Views/TidySettingsView.xaml
@@ -5,7 +5,7 @@
   xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
   xmlns:local="clr-namespace:ClangPowerTools"
   xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-  d:DesignHeight="420"
+  d:DesignHeight="440"
   d:DesignWidth="770"
   mc:Ignorable="d">
 
@@ -217,8 +217,46 @@
       </Button>
     </WrapPanel>
 
-    <!--  Auto Detect .clang-tidy file  -->
+    <!--  Path to compile database (-p) -->
     <WrapPanel Grid.Row="6" Grid.Column="1">
+      <WrapPanel.ToolTip>
+        <ToolTip>
+          <TextBlock
+            MaxWidth="400"
+            Text="{Binding Tooltip.CompilationDatabaseDir}"
+            TextWrapping="Wrap" />
+          </ToolTip>
+       </WrapPanel.ToolTip>
+
+      <TextBlock
+        Width="180"
+        Padding="10"
+        VerticalAlignment="Center"
+        FontFamily="SegoeUI"
+        FontSize="16"
+        Text="Compilation DB Dir" />
+
+      <TextBox
+        Width="450"
+        Height="30"
+        Margin="0,0,20,0"
+        VerticalContentAlignment="Center"
+        FontFamily="SegoeUI"
+        FontSize="15"
+        Text="{Binding TidyModel.CompilationDatabaseDir}" />
+
+      <Button
+        HorizontalAlignment="Left"
+        Command="{Binding CompilationDatabaseDirBrowseCommand}"
+        Style="{StaticResource SettingsButton}">
+        <Button.Content>
+          <Image Source="{StaticResource BrowseImage}" />
+        </Button.Content>
+      </Button>
+    </WrapPanel>
+
+    <!--  Auto Detect .clang-tidy file  -->
+    <WrapPanel Grid.Row="7" Grid.Column="1">
       <WrapPanel.ToolTip>
         <ToolTip>
           <TextBlock
@@ -244,7 +282,7 @@
     </WrapPanel>
 
     <!--  Format after tidy  -->
-    <WrapPanel Grid.Row="7" Grid.Column="1">
+    <WrapPanel Grid.Row="8" Grid.Column="1">
       <WrapPanel.ToolTip>
         <ToolTip>
           <TextBlock
@@ -270,7 +308,7 @@
     </WrapPanel>
 
     <!--  Tidy on save  -->
-    <WrapPanel Grid.Row="8" Grid.Column="1">
+    <WrapPanel Grid.Row="9" Grid.Column="1">
       <WrapPanel.ToolTip>
         <ToolTip>
           <TextBlock
@@ -296,7 +334,7 @@
     </WrapPanel>
 
     <!--  Apply Tidy-Fix  -->
-    <WrapPanel Grid.Row="9"
+    <WrapPanel Grid.Row="10"
                Grid.Column="1">
       <WrapPanel.ToolTip>
         <ToolTip>
@@ -330,7 +368,7 @@
     </WrapPanel>
     
     <!--  Export tidy config  -->
-    <WrapPanel Grid.Row="10" Grid.Column="1">
+    <WrapPanel Grid.Row="11" Grid.Column="1">
       <WrapPanel.ToolTip>
         <ToolTip>
           <TextBlock

--- a/ClangPowerTools/ClangPowerToolsShared/Script/GenericScriptBuilder.cs
+++ b/ClangPowerTools/ClangPowerToolsShared/Script/GenericScriptBuilder.cs
@@ -104,7 +104,7 @@ namespace ClangPowerTools.Script
 
       // Get the Clang Flags list
       if (!string.IsNullOrWhiteSpace(compilerSettings.CompileFlags))
-        parameters.Append(GetClangFlags());
+        parameters.Append(GetClangFlagsOption());
 
       // Get the continue when errors are detected flag 
       if (compilerSettings.ContinueOnError)
@@ -138,7 +138,7 @@ namespace ClangPowerTools.Script
     /// Get the clang flags in the power shell script format
     /// </summary>
     /// <returns>The clang flags</returns>
-    private string GetClangFlags()
+    private string GetClangFlagsOption()
     {
       var compilerSettings = SettingsProvider.CompilerSettingsModel;
 
@@ -182,21 +182,21 @@ namespace ClangPowerTools.Script
           using FileStream fs = new FileStream(filePath, FileMode.Create);
           using StreamWriter sw = new StreamWriter(fs);
           sw.Write(text);
-          parameters = AppendClangTidyType(filePath);
+          parameters = AppendClangTidyTypeOption(filePath);
         }
         else
         {
-          parameters = AppendClangTidyType(parameters);
+          parameters = AppendClangTidyTypeOption(parameters);
         }
       }
 
       // Get the header filter option 
       if (!string.IsNullOrWhiteSpace(tidySettings.HeaderFilter))
-        parameters += $" {GetHeaderFilters()}";
+        parameters += $" {GetHeaderFiltersOption()}";
 
       // Get the compilation database option
       if (!string.IsNullOrWhiteSpace(tidySettings.CompilationDatabaseDir))
-        parameters += $" {GetCompilationDatabaseDir(tidySettings.CompilationDatabaseDir)}";
+        parameters += $" {GetCompilationDatabaseDirOption(tidySettings.CompilationDatabaseDir)}";
 
       parameters += $" {ScriptConstants.kParallel}";
       return parameters;
@@ -208,7 +208,7 @@ namespace ClangPowerTools.Script
     /// </summary>
     /// <param name="aParameters"></param>
     /// <returns>The <"aParameters"> value with the clang tidy type with / without the clang tidy config file option attached</returns>
-    private string AppendClangTidyType(string aParameters)
+    private string AppendClangTidyTypeOption(string aParameters)
     {
       return string.Format("{0} '{1}'",
         (CommandIds.kTidyFixId == mCommandId ? ScriptConstants.kTidyFix : ScriptConstants.kTidy),
@@ -220,7 +220,7 @@ namespace ClangPowerTools.Script
     /// Get the header filter option from the Clang Tidy Option page
     /// </summary>
     /// <returns>Header filter option</returns>
-    private string GetHeaderFilters()
+    private string GetHeaderFiltersOption()
     {
       var tidySettings = SettingsProvider.TidySettingsModel;
 
@@ -252,7 +252,7 @@ namespace ClangPowerTools.Script
     /// Get the compilation database directory option from the Clang Tidy Option page
     /// </summary>
     /// <returns>Compilation database directory option</returns>
-    private string GetCompilationDatabaseDir(string compilationDatabaseDir)
+    private string GetCompilationDatabaseDirOption(string compilationDatabaseDir)
     {
         return string.Format("{0} '{1}'", ScriptConstants.kCompilationDatabaseDir, compilationDatabaseDir);
     }

--- a/ClangPowerTools/ClangPowerToolsShared/Script/GenericScriptBuilder.cs
+++ b/ClangPowerTools/ClangPowerToolsShared/Script/GenericScriptBuilder.cs
@@ -194,6 +194,10 @@ namespace ClangPowerTools.Script
       if (null != tidySettings.HeaderFilter && !string.IsNullOrWhiteSpace(tidySettings.HeaderFilter))
         parameters += $" {GetHeaderFilters()}";
 
+      // Get the compilation database option
+      if (null != tidySettings.CompilationDatabaseDir && !string.IsNullOrWhiteSpace(tidySettings.CompilationDatabaseDir))
+        parameters += $" {GetCompilationDatabaseDir(tidySettings.CompilationDatabaseDir)}";
+
       parameters += $" {ScriptConstants.kParallel}";
       return parameters;
     }
@@ -244,6 +248,14 @@ namespace ClangPowerTools.Script
       }
     }
 
+    /// <summary>
+    /// Get the compilation database directory option from the Clang Tidy Option page
+    /// </summary>
+    /// <returns>Compilation database directory option</returns>
+    private string GetCompilationDatabaseDir(string compilationDatabaseDir)
+    {
+        return string.Format("{0} '{1}'", ScriptConstants.kCompilationDatabaseDir, compilationDatabaseDir);
+    }
     #endregion
 
 

--- a/ClangPowerTools/ClangPowerToolsShared/Script/GenericScriptBuilder.cs
+++ b/ClangPowerTools/ClangPowerToolsShared/Script/GenericScriptBuilder.cs
@@ -191,11 +191,11 @@ namespace ClangPowerTools.Script
       }
 
       // Get the header filter option 
-      if (null != tidySettings.HeaderFilter && !string.IsNullOrWhiteSpace(tidySettings.HeaderFilter))
+      if (!string.IsNullOrWhiteSpace(tidySettings.HeaderFilter))
         parameters += $" {GetHeaderFilters()}";
 
       // Get the compilation database option
-      if (null != tidySettings.CompilationDatabaseDir && !string.IsNullOrWhiteSpace(tidySettings.CompilationDatabaseDir))
+      if (!string.IsNullOrWhiteSpace(tidySettings.CompilationDatabaseDir))
         parameters += $" {GetCompilationDatabaseDir(tidySettings.CompilationDatabaseDir)}";
 
       parameters += $" {ScriptConstants.kParallel}";

--- a/ClangPowerTools/ClangPowerToolsShared/Script/ScriptConstants.cs
+++ b/ClangPowerTools/ClangPowerToolsShared/Script/ScriptConstants.cs
@@ -110,6 +110,7 @@ namespace ClangPowerTools
 
     public const string kHeaderFilter = "-header-filter";
     public const string kTidyFile = ".clang-tidy";
+    public const string kCompilationDatabaseDir = "-compilation-database-dir";
 
     public const string kClangFormatStyle = "-format-style";
 

--- a/ClangPowerTools/ClangPowerToolsShared/Tooling/v1/clang-build.ps1
+++ b/ClangPowerTools/ClangPowerToolsShared/Tooling/v1/clang-build.ps1
@@ -172,6 +172,10 @@ param( [alias("proj")]
        [Parameter(Mandatory=$false, HelpMessage="Enable Clang-Tidy to run on header files")]
        [string]   $aTidyHeaderFilter
 
+     , [alias("compilation-database-dir")]
+       [Parameter(Mandatory=$false, HelpMessage="Specify a path of a directory where compile_commands.json is located.")]
+       [string]   $aCompilationDatabaseDir
+
      , [alias("format-style")]
        [Parameter(Mandatory=$false, HelpMessage="Used with 'tidy-fix'; tells CLANG TIDY-FIX to also format the fixed file(s)")]
        [string]   $aAfterTidyFixFormatStyle
@@ -240,12 +244,11 @@ Set-Variable -name kClangTidyFixExportFixes -value "--export-fixes="    -option 
 
 Set-Variable -name kClangCompiler           -value "clang++.exe"        -option Constant
 
-Set-Variable -name kClangTidyFlags            -value @("-quiet"
-                                                      ,"--")            -option Constant
 Set-Variable -name kClangTidyFlagHeaderFilter -value "-header-filter="  -option Constant
 Set-Variable -name kClangTidyFlagChecks       -value "-checks="         -option Constant
 Set-Variable -name kClangTidyUseFile          -value ".clang-tidy"      -option Constant
 Set-Variable -name kClangTidyFormatStyle      -value "-format-style="   -option Constant
+Set-Variable -name kClangTidyCompilationDatabaseDir -value "-p="        -option Constant
 
 Set-Variable -name kClangTidyFlagTempFile     -value ""
 
@@ -826,9 +829,10 @@ Function Get-TidyCallArguments( [Parameter(Mandatory=$false)][string[]] $preproc
                               , [Parameter(Mandatory=$false)][string[]] $forceIncludeFiles
                               , [Parameter(Mandatory=$true)][string]   $fileToTidy
                               , [Parameter(Mandatory=$false)][string]  $pchFilePath
-                              , [Parameter(Mandatory=$false)][switch]  $fix)
+                              , [Parameter(Mandatory=$false)][switch]  $fix
+                              , [Parameter(Mandatory=$false)][string]  $compilationDatabaseDir)
 {
-  [string[]] $tidyArgs = @()
+  [string[]] $tidyArgs = @('-quiet')
   if ($fix)
   {
     # Map tidy-fix replacements temprorary file path to original file path
@@ -864,7 +868,20 @@ Function Get-TidyCallArguments( [Parameter(Mandatory=$false)][string[]] $preproc
     }
   }
 
-  $tidyArgs += $kClangTidyFlags
+  if (![string]::IsNullOrEmpty($compilationDatabaseDir))
+  {
+      if ($compilationDatabaseDir -eq '_')
+      {
+          $compilationDatabaseDir = Get-SourceDirectory
+      }
+      # When passed to cmd.exe the quote cannot be preceded by a backslash or it's escaped
+      $tidyArgs += "$kClangTidyCompilationDatabaseDir`"$($compilationDatabaseDir.TrimEnd("\"))`""
+      # When we use compilation database, we don't need to add further args with
+      # compilation flags
+      return $tidyArgs
+  }
+
+  $tidyArgs += "--"
 
   $tidyArgs += Get-ClangIncludeDirectories -includeDirectories           $includeDirectories `
                                            -additionalIncludeDirectories $additionalIncludeDirectories
@@ -900,7 +917,8 @@ Function Get-ExeCallArguments( [Parameter(Mandatory=$false)][string]       $pchF
                              , [Parameter(Mandatory=$false)][string[]]     $preprocessorDefinitions
                              , [Parameter(Mandatory=$false)][string[]]     $forceIncludeFiles
                              , [Parameter(Mandatory=$true) ][string]       $currentFile
-                             , [Parameter(Mandatory=$true) ][WorkloadType] $workloadType)
+                             , [Parameter(Mandatory=$true) ][WorkloadType] $workloadType
+                             , [Parameter(Mandatory=$false)][string]       $compilationDatabaseDir)
 {
   switch ($workloadType)
   {
@@ -915,13 +933,15 @@ Function Get-ExeCallArguments( [Parameter(Mandatory=$false)][string]       $pchF
                                            -additionalIncludeDirectories  $additionalIncludeDirectories `
                                            -forceIncludeFiles             $forceIncludeFiles `
                                            -pchFilePath                   $pchFilePath `
-                                           -fileToTidy                    $currentFile }
+                                           -fileToTidy                    $currentFile `
+                                           -compilationDatabaseDir        $compilationDatabaseDir}
     TidyFix { return Get-TidyCallArguments -preprocessorDefinitions       $preprocessorDefinitions `
                                            -includeDirectories            $includeDirectories `
                                            -additionalIncludeDirectories  $additionalIncludeDirectories `
                                            -forceIncludeFiles             $forceIncludeFiles `
                                            -pchFilePath                   $pchFilePath `
                                            -fileToTidy                    $currentFile `
+                                           -compilationDatabaseDir        $compilationDatabaseDir `
                                            -fix}
   }
 }
@@ -1005,17 +1025,20 @@ Function Run-ClangJobs( [Parameter(Mandatory=$true)] $clangJobs
     [string] $clangConfigContent = ""
     if ($job.FilePath -like '*tidy*')
     {
-      # We have to separate Clang args from Tidy args
-      $splitparams = $job.ArgumentList -split " -- "
-      $clangConfigContent = $splitparams[1]
-
-      # We may have an explicit .clang-tidy check-flag config file to be used
-      if (![string]::IsNullOrWhiteSpace($job.TidyFlagsTempFile) -and (Test-Path -LiteralPath $job.TidyFlagsTempFile))
+      if (!$job.ArgumentList -like "$($job.kClangTidyCompilationDatabaseDir)*")
       {
-        $splitparams[0] += " --config-file=""$($job.TidyFlagsTempFile)"" "
-      }
+          # We have to separate Clang args from Tidy args
+          $splitparams = $job.ArgumentList -split " -- "
+          $clangConfigContent = $splitparams[1]
 
-      $job.ArgumentList = "$($splitparams[0]) -- --config ""$clangConfigFile"""
+          # We may have an explicit .clang-tidy check-flag config file to be used
+          if (![string]::IsNullOrWhiteSpace($job.TidyFlagsTempFile) -and (Test-Path -LiteralPath $job.TidyFlagsTempFile))
+          {
+            $splitparams[0] += " --config-file=""$($job.TidyFlagsTempFile)"" "
+          }
+
+          $job.ArgumentList = "$($splitparams[0]) -- --config ""$clangConfigFile"""
+      }
     }
     else
     {
@@ -1034,7 +1057,6 @@ Function Run-ClangJobs( [Parameter(Mandatory=$true)] $clangJobs
     # When PowerShell encounters errors, the first one is handled differently from consecutive ones
     # To circumvent this, do not execute the job directly, but execute it via cmd.exe
     # See also https://stackoverflow.com/a/35980675
-    
     $callOutput = cmd /c "$($job.FilePath) $($job.ArgumentList) 2>&1" | Out-String
 
     $callSuccess = $LASTEXITCODE -eq 0
@@ -1550,7 +1572,8 @@ Function Process-Project( [Parameter(Mandatory=$true)] [string]       $vcxprojPa
                                                -forceIncludeFiles       $cppForceIncludes `
                                                -currentFile             $cpp `
                                                -includeDirectories      $includeDirectories `
-                                               -additionalIncludeDirectories $additionalIncludeDirectories
+                                               -additionalIncludeDirectories $additionalIncludeDirectories `
+                                               -compilationDatabaseDir  $aCompilationDatabaseDir
 
     $newJob = New-Object PsObject -Prop @{ 'FilePath'          = $exeToCall
                                          ; 'WorkingDirectory'  = Get-SourceDirectory
@@ -1558,6 +1581,7 @@ Function Process-Project( [Parameter(Mandatory=$true)] [string]       $vcxprojPa
                                          ; 'File'              = $cpp
                                          ; 'JobCounter'        = 0 <# will be lazy initialized #>
                                          ; 'TidyFlagsTempFile' = $kClangTidyFlagTempFile
+                                         ; 'kClangTidyCompilationDatabaseDir' = $kClangTidyCompilationDatabaseDir
                                          }
     $clangJobs += $newJob
   }


### PR DESCRIPTION
This PR adds an option to Clang Tidy settings to specify path to directory where `compile_commands.json` file is located.  It is passed to clang-tidy.exe as -p option instead of compilation flags built by clang power tools. 

This allows to use Clang Power Tools with projects generated by Unreal Engine.

This should resolve issue #1072 